### PR TITLE
fixed projectGeneratorLegacy to work on OSX so all examples can be bu…

### DIFF
--- a/projectGeneratorLegacy/src/main.cpp
+++ b/projectGeneratorLegacy/src/main.cpp
@@ -99,11 +99,10 @@ int main(  int argc, char *argv[]  ){
 	}
 #else 
     cout << "IN HERE!!" << endl;
-    ofAppGlutWindow window;
-    ofSetupOpenGL(&window, 1024,768, OF_WINDOW);
+    ofSetupOpenGL(1024,768, OF_WINDOW);
     ofApp * app = new ofApp;
     app->buildAllExamples = false;
-    ofRunApp( app );
+    return ofRunApp( app );
     
 #endif
     


### PR DESCRIPTION
Hi! I cloned the most recent repo of openFrameworks and tried to generate all the examples via the projectGeneratorLegacy. It threw errors complaining about GLUT, I fixed the issues and was able to generate xcode projects for all the examples for OSX. 

This seems like the only way to generate the example for OSX if you are using the git version of openFrameworks, please correct me if I'm wrong! 

Thanks for OF 

<3
Reza