### PR TITLE
adding osx info about how to make an executable and add a shell script

### DIFF
--- a/commandLine/prepareOsx.sh
+++ b/commandLine/prepareOsx.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "copying the executable out of the app"
+
+cp bin/commandLine.app/Contents/MacOS/commandLine bin/commandLineExe
+
+echo "deleting the app"
+
+rm -rf bin/commandLine.app
+
+echo "renaming the executable"
+
+mv bin/commandLineExe bin/commandLine
+

--- a/commandLine/readme.md
+++ b/commandLine/readme.md
@@ -1,6 +1,6 @@
 when you compile this on OSX, we remove the fmod dynamic lib dependency and strip the exectuable from the app package (on osx, OF compiles to an app but the actual exectuable is deeper in the package).  This is happening the project.xcconfig and in the build phases if you are curious.
 
-once compiled you should see commandLinePG next to the package -- give that a try.  that's what you want to use.
+on OS X, once compiled, run the prepareOsx.sh script - that copies the executable out of the .app and replaces the .app with an executable that you can run at the command line. 
 
 here's an example of creating a project, setting the OF path (../../../../) which is the path to OF from that point in the repo, using the create mode, and setting the path of the project you want to create (paths can be relative or absolute)
 


### PR DESCRIPTION
this is adding a shell script for pulling the executable out of the .app and added some info in the readme (this used to be part of the xcproj build step but is now broken out since we've lost that using the templates) 