### PR TITLE
allow for local addons to be specified via absolute paths

### DIFF
--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -234,8 +234,18 @@ void baseProject::addAddon(std::string addonName){
     ofAddon addon;
     addon.pathToOF = getOFRelPath(projectDir);
     addon.pathToProject = ofFilePath::getAbsolutePath(projectDir);
+    
+
+    
     auto localPath = ofFilePath::join(addon.pathToProject, addonName);
-    if(ofDirectory(localPath).exists()){
+    
+    if (ofDirectory(addonName).exists()){
+        // if it's an absolute path, convert to relative...
+        string relativePath = ofFilePath::makeRelative(addon.pathToProject, addonName);
+        addonName = relativePath;
+        addon.isLocalAddon = true;
+        addon.fromFS(addonName, target);
+    } else if(ofDirectory(localPath).exists()){
         addon.isLocalAddon = true;
         addon.fromFS(addonName, target);
     }else{


### PR DESCRIPTION
this is a PR to work through getting local addons to work in the gui.  

I am allowing them to be specified at the command line via absolute paths which get converted to relative paths to the project in the command line tool as the project is generated (ie, if you have a folder called localAddons in the root, and you pass in -a"/users/......./ofxTemp" it will be like adding ../../../localAddons/ofxTemp to your project) .  On the gui side, it's much easier to take a relative path to OF for the local addon (or absoute path) and store it internally as an absolute path....

I've added support in settings.json and in the gui now, just working on storing and passing through the right things, and on dealing with parsing addons.make on import. 

as I get stuff to work, I'll check it in...