### PR TITLE
Trim whitespace/newlines when parsing addons

### DIFF
--- a/projectGeneratorElectron/app.js
+++ b/projectGeneratorElectron/app.js
@@ -222,6 +222,7 @@ ipc.on('selectAddons', function(arg) {
     //haystack.indexOf(needle) >= 0
 
     for (var i = 0; i < arg.length; i++) {
+        arg[i] = arg[i].trim();
         // first, check if it's already picked, then do nothing
         if (addonsAlreadyPicked.indexOf(arg[i]) >= 0){
             console.log("already picked"); // alread picked


### PR DESCRIPTION
TL;DR There was a LF/CRLF issue when parsing addons.make

The first time I tried this, instead of seeing the message about local addons, I got the warning about missing addons for both my standard & local addons. I thought this could've been because I opened the gui, then changed my OF path, and maybe it didn't rescan the addons folder? But even after relaunching the gui with the OF path already set I was still seeing it.

![pg-local-addons](https://cloud.githubusercontent.com/assets/2334552/10579965/26d257cc-7649-11e5-9abb-dc40238e9276.jpg)

![pg-local-addons-settings](https://cloud.githubusercontent.com/assets/2334552/10579972/29fb6f2e-7649-11e5-852a-a896048bb701.jpg)

I ran the pg from the command line with the same paths to make sure that worked, and that looked good:

```
C:\Users\mattfelsen\Code\openFrameworks\github\apps\projectGenerator\projectGeneratorElectron\app>projectGenerator.exe -o"C:\Users\mattfelsen\Code\Projects\CMA2\openFrameworks" --addons="ofxGui,ofxOpenCv,../../ExternalAddons/ofxGrabCam" C:\Users\mattfelsen\Code\Projects\CMA2\Sketches\SilhouettesFromPointCloud

[notice ] -----------------------------------------------
[notice ] setting OF path to: C:\Users\mattfelsen\Code\Projects\CMA2\openFrameworks
[notice ] from -o option
[notice ] target platform is: vs
[notice ] updating project C:\Users\mattfelsen\Code\Projects\CMA2\Sketches\SilhouettesFromPointCloud
[notice ] saving addons.make
[notice ] project updated!
[notice ] -----------------------------------------------


1 project updated [notice ] in 1.1875 seconds
```

Then when going back to the gui I saw it was showing the correct warning:

![pg-local-addons-working](https://cloud.githubusercontent.com/assets/2334552/10580567/0846a74c-764c-11e5-866d-1b7bd19d4a29.jpg)

When I `git diff` on `addons.make` there are no content changes but there's a notice on line-endings:

```
$ git diff Sketches/SilhouettesFromPointCloud/addons.make
warning: LF will be replaced by CRLF in Sketches/SilhouettesFromPointCloud/addons.make.
The file will have its original line endings in your working directory.
```

Sure enough, if I clear the changes to `addons.make` the gui went back to saying the addons were missing. So I just added a `trim()` on the strings.