### PR TITLE
open in IDE

### DIFF
--- a/projectGeneratorElectron/app.js
+++ b/projectGeneratorElectron/app.js
@@ -293,6 +293,10 @@ ipc.on('selectAddons', function(arg) {
 //-------------------------------------------
 // allow main to send UI messages
 ipc.on('sendUIMessage', function(arg) {
+
+    // check if it has "success" message: 
+
+
     displayModal(arg);
 });
 
@@ -479,6 +483,11 @@ function setup() {
                 enableAdvancedMode(false);
             }
         });
+
+         $("#IDEButton").on("click", function() {  
+            launchInIDE();
+         });
+
 
          $("#verboseOption").checkbox();
          $("#verboseOption").on("change", function() {
@@ -848,6 +857,13 @@ function displayModal(message) {
 		var shell = require('shell');
 		shell.openExternal( $(this).prop("href") );
     });
+
+    if (message.indexOf("Success!") > -1){
+        $("#IDEButton").show();
+    } else {
+        $("#IDEButton").hide();
+    }
+
     $("#uiModal").modal('show');
 }
 
@@ -913,3 +929,16 @@ function getRandomSketchName(){
         ipc.send('getRandomSketchName', path );
     }
 }
+
+function launchInIDE(){
+
+console.log("sdfsadfasdf?");
+    var project = {};
+    project['projectName'] = $("#projectName").val();
+    project['projectPath'] = $("#projectPath").val();
+    project['platform'] = defaultSettings['defaultPlatform']; // ignores OS selection
+    project['ofPath'] = $("#ofPath").val();
+
+    ipc.send('launchProjectinIDE', project );
+}
+

--- a/projectGeneratorElectron/app.js
+++ b/projectGeneratorElectron/app.js
@@ -932,7 +932,6 @@ function getRandomSketchName(){
 
 function launchInIDE(){
 
-console.log("sdfsadfasdf?");
     var project = {};
     project['projectName'] = $("#projectName").val();
     project['projectPath'] = $("#projectPath").val();

--- a/projectGeneratorElectron/index.html
+++ b/projectGeneratorElectron/index.html
@@ -67,8 +67,7 @@ position: fixed;
 			font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
 			font-size: 9px;
 			white-space: pre;
- 			word-wrap: normal;
-  			overflow-x: scroll;
+ 			word-wrap: break-word;
 		}
 
 		</style>
@@ -301,6 +300,7 @@ position: fixed;
 				<p>Sorry, I've got nothing to say...</p>
 			</div>
 			<div class="actions">
+				<div class="ui button" id="IDEButton" style="display: none;">Open in IDE</div>
 				<div class="ui cancel button">Close</div>
 			</div>
 		</div>

--- a/projectGeneratorElectron/index.html
+++ b/projectGeneratorElectron/index.html
@@ -300,7 +300,7 @@ position: fixed;
 				<p>Sorry, I've got nothing to say...</p>
 			</div>
 			<div class="actions">
-				<div class="ui button" id="IDEButton" style="display: none;">Open in IDE</div>
+				<div class="ui cancel button" id="IDEButton" style="display: none;">Open in IDE</div>
 				<div class="ui cancel button">Close</div>
 			</div>
 		</div>

--- a/projectGeneratorElectron/index.js
+++ b/projectGeneratorElectron/index.js
@@ -796,29 +796,25 @@ ipc.on('launchProjectinIDE', function(event, arg) {
 
     // // launch xcode
     if( arg.platform == 'osx' ){
-          var osxPath = pathTemp.join(fullPath, arg['projectName'] + '.xcodeproj');
+        var osxPath = pathTemp.join(fullPath, arg['projectName'] + '.xcodeproj');
         console.log( osxPath );
         if( fsTemp.statSync(osxPath).isDirectory() == true ){ // note: .xcodeproj is a folder, not a file
-            var exec = require('child_process').exec;
-            exec('open ' + osxPath, function callback(error, stdout, stderr){
-                event.sender.send('projectLaunchCompleted', (error==null) );
-                return;
-            });
+                var exec = require('child_process').exec;
+                exec('open ' + osxPath, function callback(error, stdout, stderr){
+                    return;
+                });
         }
         else {
-            // console.log('OSX project file not found!');
-            // event.sender.send('projectLaunchCompleted', false );
-            // return;
+            console.log('OSX project file not found!');
         }
-    }
-
-    // linux
-    else if( arg.platform == 'linux' || arg.platform == 'linux64' ){
-        // xdg-open $DESTINATION_PATH
-    }
-
-    // unknown platform
-    else {
+    } else if( arg.platform == 'linux' || arg.platform == 'linux64' ){
+        var linuxPath = pathTemp.join(fullPath, arg['projectName'] + '.cbp');
+        console.log( linuxPath );
+        var exec = require('child_process').exec;
+        exec('xdg-open ' + linuxPath, function callback(error, stdout, stderr){
+            return;
+        });
+    } else {
         console.log("Unsupported platform for Launch feature...");
         event.sender.send('projectLaunchCompleted', false );
                 return;

--- a/projectGeneratorElectron/index.js
+++ b/projectGeneratorElectron/index.js
@@ -92,8 +92,8 @@ var platforms = {
     "osx": "OS X (Xcode)",
     "vs": "Windows (Visual Studio 2015)",
     "ios": "iOS (Xcode)",
-    "linux": "Linux 32-bit (Code::Blocks)",
-    "linux64": "Linux 64-bit (Code::Blocks)",
+    "linux": "Linux 32-bit (qtCreator)",
+    "linux64": "Linux 64-bit (qtCreator)",
     "linuxarmv6l": "Linux ARMv6 (Makefiles)",
     "linuxarmv7l": "Linux ARMv7 (Makefiles)"
 };
@@ -808,7 +808,7 @@ ipc.on('launchProjectinIDE', function(event, arg) {
             console.log('OSX project file not found!');
         }
     } else if( arg.platform == 'linux' || arg.platform == 'linux64' ){
-        var linuxPath = pathTemp.join(fullPath, arg['projectName'] + '.cbp');
+        var linuxPath = pathTemp.join(fullPath, arg['projectName'] + '.qbs');
         console.log( linuxPath );
         var exec = require('child_process').exec;
         exec('xdg-open ' + linuxPath, function callback(error, stdout, stderr){

--- a/projectGeneratorElectron/index.js
+++ b/projectGeneratorElectron/index.js
@@ -814,10 +814,13 @@ ipc.on('launchProjectinIDE', function(event, arg) {
         exec('xdg-open ' + linuxPath, function callback(error, stdout, stderr){
             return;
         });
-    } else {
-        console.log("Unsupported platform for Launch feature...");
-        event.sender.send('projectLaunchCompleted', false );
-                return;
+    } else {    
+        var windowsPath = pathTemp.join(fullPath, arg['projectName'] + '.sln');
+        console.log( windowsPath );
+        var exec = require('child_process').exec;
+        exec('start ' + windowsPath, function callback(error, stdout, stderr){
+            return;
+        });
     }
 });
 


### PR DESCRIPTION
this adds an open in IDE button on success which seems like the simplest way to add this feature (we can work on a better system post 0.9).  It only works on OSX at the moment.

<img width="549" alt="screen shot 2015-10-29 at 9 38 59 am" src="https://cloud.githubusercontent.com/assets/142897/10819909/1fefc856-7e21-11e5-99ea-3393375fd4df.png">

this PR also fixes a bug with filtering out addons that causes an error when you have the array path wrong (and thus the addon array is null) 