### PR TITLE
Add a few features to addon_config.mk

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -273,7 +273,7 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 	}
 
 	if(variable == "ADDON_DATA"){
-		addReplaceStringVector(data,value,addonRelPath,addToValue);
+		addReplaceStringVector(data,value,"",addToValue);
 	}
 
 	if(variable == "ADDON_LIBS_EXCLUDE"){

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -253,7 +253,30 @@ void baseProject::addAddon(std::string addonName){
         auto standardPath = ofFilePath::join(ofFilePath::join(getOFRoot(), "addons"), addonName);
         addon.fromFS(standardPath, target);
     }
+
     addAddon(addon);
+
+    // Process values from ADDON_DATA
+    if (addon.data.size()) {
+        string dest = ofFilePath::join(projectDir, "bin/data/");
+
+        for (auto& filename : addon.data) {
+            ofFile src(ofFilePath::join(addon.addonPath, filename));
+
+            if (src.isFile()) {
+                src.copyTo(ofFilePath::join(dest, src.getFileName()), false, true);
+            } else if (src.isDirectory()) {
+                string folderPath = ofFilePath::join(addon.addonPath, filename);
+                ofDirectory dir(folderPath);
+                dir.listDir();
+                for (auto& file : dir) {
+                    file.copyTo(ofFilePath::join(dest, file.getFileName()), false, true);
+                }
+            } else {
+                ofLogWarning() << filename << " is not a file or directory, skipping";
+            }
+        }
+    }
 }
 
 void baseProject::addAddon(ofAddon & addon){

--- a/ofxProjectGenerator/src/projects/baseProject.h
+++ b/ofxProjectGenerator/src/projects/baseProject.h
@@ -67,7 +67,7 @@ public:
     virtual void addAfterRule(std::string script){}
 
     virtual void addAddon(std::string addon);
-	virtual void addAddon(ofAddon & addon);
+    virtual void addAddon(ofAddon & addon);
 
     std::string getName() { return projectName;}
     std::string getPath() { return projectDir; }

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -1175,6 +1175,11 @@ void xcodeProject::addAddon(ofAddon & addon){
         ofLogVerbose() << "adding addon libs: " << addon.libs[i].path;
         addLibrary(addon.libs[i]);
     }
+    for(int i=0;i<(int)addon.dllsToCopy.size();i++){
+        ofLogVerbose() << "adding addon dlls to bin: " << addon.dllsToCopy[i];
+        string dll = ofFilePath::join("addons/" + addon.name, addon.dllsToCopy[i]);
+        ofFile(ofFilePath::join(getOFRoot(),dll)).copyTo(ofFilePath::join(projectDir,"bin/"),false,true);
+    }
     for(int i=0;i<(int)addon.cflags.size();i++){
         ofLogVerbose() << "adding addon cflags: " << addon.cflags[i];
         addCFLAG(addon.cflags[i]);


### PR DESCRIPTION
The first commit here re-adds support for the ADDON_DATA field (see https://github.com/openframeworks/openFrameworks/issues/2903). It works for both files and folders, but notably, there is no parsing of any wildcards as suggested here https://github.com/bakercp/ofxAddonTemplate/blob/3e8508dbd0735809657df7ddd803bbd6bbcb8117/addon_config.mk#L55-L57

The second commit adds support for ADDON_DLLS_TO_COPY to Xcode projects so that addons with dylibs can have these added to the project's bin folder. The "DLL" term is kind of odd here and could perhaps be changed to something like ADDON_DYNAMIC_LIBS or ADDON_SHARED_LIBS which brings it more in line with ADDON_LIBS and feels appropriate for both .dll and .dylib files. Potentially this could also get added to qtcreator and code::blocks projects for .so files?

As an alternative, a different approach could be to automatically add any libs that end with .dll, .dylib, and .so to the bin folder.