### PR TITLE
Fix paths for local addons when parsing addon_config.mk

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -194,7 +194,10 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 		return;
 	}
 
-	string addonRelPath = ofFilePath::addTrailingSlash(pathToOF) + "addons/" + name;
+
+	string addonRelPath;
+	if (!isLocalAddon) addonRelPath = ofFilePath::addTrailingSlash(pathToOF) + "addons/" + name;
+	else addonRelPath = addonPath;
 
 	if(variable == "ADDON_DESCRIPTION"){
 		addReplaceString(description,value,addToValue);


### PR DESCRIPTION
When parsing paths from addon_config.mk for things like ADDON_INCLUDES, ADDON_SOURCES, etc. in local addons, the path was still relative to OF instead of the addon. For example, this is what I was getting with this [addon_config.mk file](https://github.com/labatrockwell/ofxLibwebsockets/blob/79e4afce94137b13166825d9f66901a015a93dfe/addon_config.mk#L16-L22) from [ofxLibwebsockets/0.9.0](https://github.com/labatrockwell/ofxLibwebsockets/tree/0.9.0)

![config-bad](https://cloud.githubusercontent.com/assets/2334552/11195746/8fbd03a6-8c81-11e5-8386-2d54510adc6a.jpg)

You can see the paths for the other addons, which are picked up from the filesystem and not from addon_config.mk, are properly resolved. And with this fix:

![config-good](https://cloud.githubusercontent.com/assets/2334552/11195752/98f3f20e-8c81-11e5-9700-0fbd30eaef57.jpg)