### PR TITLE
Fixes 0.9.1 Issues

### DIFF
--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -341,17 +341,21 @@ bool xcodeProject::createProjectFile(){
 				dataDirectory.create(false);
 			}
 		}
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default-568h@2x~iphone.png"),projectDir + "/bin/data/Default-568h@2x~iphone.png", true, true);
-		ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default.png"),projectDir + "/bin/data/Default.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default@2x.png"),projectDir + "/bin/data/Default@2x.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default@2x~ipad.png"),projectDir + "/bin/data/Default@2x~ipad.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default@2x~iphone.png"),projectDir + "/bin/data/Default@2x~iphone.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default~ipad.png"),projectDir + "/bin/data/Default~ipad.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default~iphone.png"),projectDir + "/bin/data/Default~iphone.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon-72.png"),projectDir + "/bin/data/Icon-72.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon-72@2x.png"),projectDir + "/bin/data/Icon-72@2x.png", true, true);
-		ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon.png"),projectDir + "/bin/data/Icon.png", true, true);
-        ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon@2x.png"),projectDir + "/bin/data/Icon@2x.png", true, true);
+        if(!ofFile::doesFileExist(projectDir + "/bin/data/Default-568h@2x~iphone.png", true)) {
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default-568h@2x~iphone.png"),projectDir + "/bin/data/Default-568h@2x~iphone.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default.png"),projectDir + "/bin/data/Default.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default@2x.png"),projectDir + "/bin/data/Default@2x.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default@2x~ipad.png"),projectDir + "/bin/data/Default@2x~ipad.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default@2x~iphone.png"),projectDir + "/bin/data/Default@2x~iphone.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default~ipad.png"),projectDir + "/bin/data/Default~ipad.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Default~iphone.png"),projectDir + "/bin/data/Default~iphone.png", true, true);
+        }
+        if(!ofFile::doesFileExist(projectDir + "/bin/data/Icon-72.png", true)) {
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon-72.png"),projectDir + "/bin/data/Icon-72.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon-72@2x.png"),projectDir + "/bin/data/Icon-72@2x.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon.png"),projectDir + "/bin/data/Icon.png", true, true);
+            ofFile::copyFromTo(ofFilePath::join(templatePath,"bin/data/Icon@2x.png"),projectDir + "/bin/data/Icon@2x.png", true, true);
+        }
     }
 
     // this is for xcode 4 scheme issues. but I'm not sure this is right.

--- a/projectGeneratorLegacy/src/main.cpp
+++ b/projectGeneratorLegacy/src/main.cpp
@@ -35,7 +35,7 @@ int main(  int argc, char *argv[]  ){
 				}else if(arg=="linuxarmv7l"){
 					app->targetsToMake.push_back( OF_TARGET_LINUXARMV7L );
 				}else if(arg=="win_cb"){
-					app->targetsToMake.push_back( OF_TARGET_WINGCC );
+					app->targetsToMake.push_back( OF_TARGET_MINGW );
 				}else if(arg=="vs"){
 					app->targetsToMake.push_back( OF_TARGET_WINVS );
 				}else if(arg=="osx"){
@@ -50,7 +50,7 @@ int main(  int argc, char *argv[]  ){
 					app->targetsToMake.push_back( OF_TARGET_LINUX64 );
 					app->targetsToMake.push_back( OF_TARGET_LINUXARMV6L );
 					app->targetsToMake.push_back( OF_TARGET_LINUXARMV7L );
-					app->targetsToMake.push_back( OF_TARGET_WINGCC );
+					app->targetsToMake.push_back( OF_TARGET_MINGW );
 					app->targetsToMake.push_back( OF_TARGET_WINVS );
 					app->targetsToMake.push_back( OF_TARGET_OSX );
 					app->targetsToMake.push_back( OF_TARGET_IPHONE );

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -11,12 +11,13 @@ if [ $ret -ne 0 ]; then
       echo "Failed building Project Generator"
       exit 1
 fi
-if [ "${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}" = "openframeworks/projectGenerator/master" ]; then
+echo "${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}";
+if [[ "${TRAVIS_REPO_SLUG}/${TRAVIS_BRANCH}" = "openframeworks/projectGenerator/master" && "${TRAVIS_PULL_REQUEST}" = "false" ]]; then
     openssl aes-256-cbc -K $encrypted_cd38768cbb9d_key -iv $encrypted_cd38768cbb9d_iv -in scripts/id_rsa.enc -out scripts/id_rsa -d
     cp scripts/ssh_config ~/.ssh/config
     chmod 600 scripts/id_rsa
     scp -i scripts/id_rsa commandLine/bin/projectGenerator tests@198.61.170.130:projectGenerator_builds/projectGenerator_osx_new
     ssh -i scripts/id_rsa tests@198.61.170.130 "mv projectGenerator_builds/projectGenerator_osx_new projectGenerator_builds/projectGenerator_osx"
 fi
-rm scripts/id_rsa
+rm -rf scripts/id_rsa
 


### PR DESCRIPTION
- Fixes Projectgenerator ios - overwrites ios icons/images on project update https://github.com/openframeworks/openFrameworks/issues/4137
(Does a quick check for the First AppIcon and the major splash screen image, did it like this rather than individually as this whole part of the code will be replaced after 0.10.0 with the new Image Assets folder)

- Fixes issues related to "Fix for Updated OF_TARGET_WINGCC changed to OF_TARGET_MINGW
Related to: https://github.com/openframeworks/openFrameworks/pull/4561 "

