### PR TITLE
print correct running times

### DIFF
--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -52,7 +52,6 @@ enum pgMode {
 };
 
 
-float               startTime;
 int                 nProjectsUpdated;
 int                 nProjectsCreated;
 
@@ -352,7 +351,6 @@ int main(int argc, char* argv[]){
     bHelpRequested = false;
     bListTemplates = false;
     targets.push_back(ofGetTargetPlatform());
-    startTime = 0;
     nProjectsUpdated = 0;
     nProjectsCreated = 0;
     string projectName = "";
@@ -433,7 +431,6 @@ int main(int argc, char* argv[]){
     
     // ------------------------------------------------------ post parse
     
-    startTime = ofGetElapsedTimef();
     nProjectsUpdated = 0;
     nProjectsCreated = 0;
     of::priv::initutils();
@@ -627,11 +624,10 @@ int main(int argc, char* argv[]){
     }
 
     consoleSpace();
-    float elapsedTime = ofGetElapsedTimef() - startTime;
     if (nProjectsCreated > 0) cout << nProjectsCreated << " project created ";
     if (nProjectsUpdated == 1)cout << nProjectsUpdated << " project updated ";
     if (nProjectsUpdated > 1) cout << nProjectsUpdated << " projects updated ";
-    ofLogNotice() << "in " << elapsedTime << " seconds" << endl;
+    ofLogNotice() << "in " << ofGetElapsedTimef() << " seconds" << endl;
     consoleSpace();
 
 	


### PR DESCRIPTION
The commandLine project generator was reporting large, negative elapsed times:

```
[notice ] -----------------------------------------------
[notice ] setting OF path to: /home/brendan/of_v0.9.3_linux64_release/
[notice ] from -o option
[notice ] target platform is: linux64
[notice ] updating project /home/brendan/of_v0.9.3_linux64_release/apps/myApps/test
[notice ] saving addons.make
[notice ] project updated! 
[notice ] -----------------------------------------------

1 project updated [notice ] in -8528.8 seconds
```

This was due to the fact that OF's start time values are being set in [this call to `initutils()`](https://github.com/openframeworks/projectGenerator/blob/master/commandLine/src/main.cpp#L439)  _after_ the [start time had been recorded](https://github.com/openframeworks/projectGenerator/blob/master/commandLine/src/main.cpp#L436). Since these calls were so close together, I thought it simplest to use only one `ofGetElapsedTimef()`, and let `initutils()` mark the start time for us.

The project generator now outputs:

```
[notice ] -----------------------------------------------
[notice ] setting OF path to: /home/brendan/of_v0.9.3_linux64_release/
[notice ] from -o option
[notice ] target platform is: linux64
[notice ] updating project /home/brendan/of_v0.9.3_linux64_release/apps/myApps/test
[notice ] saving addons.make
[notice ] project updated! 
[notice ] -----------------------------------------------


1 project updated [notice ] in 0.218913 seconds
```
