### PR TITLE
VS: Fix issue with .dlls in addons

### DIFF
--- a/ofxProjectGenerator/src/projects/visualStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.cpp
@@ -348,16 +348,6 @@ void visualStudioProject::addAddon(ofAddon & addon){
         addInclude(addon.includePaths[i]);
     }
 
-    // divide libs into debug and release libs
-    // the most reliable would be to have seperate
-    // folders for debug and release libs
-    // i'm gonna start with a ghetto approach of just
-    // looking for duplicate names except for a d.lib
-    // at the end -> this is not great as many
-    // libs compile with the d somewhere in the middle of the name...
-
-    vector <string> possibleReleaseOrDebugOnlyLibs;
-
     for(auto & lib: addon.libs){
 		addLibrary(lib);
     }

--- a/ofxProjectGenerator/src/projects/visualStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.cpp
@@ -265,7 +265,20 @@ void visualStudioProject::addLibrary(const LibraryBinary & lib){
     string libFolder = libraryName.substr(0,found);
     string libName = libraryName.substr(found+1);
 
-    // do the path, then the library
+	string libBaseName;
+	string libExtension;
+
+	splitFromLast( libName, ".", libBaseName, libExtension );
+
+	if ( libExtension != "lib" ){
+		// In vs, you must only link against `.lib` files, *not* `.dlls`. 
+		// corresponding `.dll` files must be named in addon_config.mk
+		// under ADDON_DLLS_TO_COPY so that they will be copied into
+		// the app bin path. Therefore we return early.
+		return;
+	}
+
+	// ---------| invariant: libExtension is `lib`
 
     // paths for libraries
 	string linkPath;

--- a/ofxProjectGenerator/src/projects/visualStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.cpp
@@ -397,8 +397,8 @@ void visualStudioProject::addAddon(ofAddon & addon){
 
 	for(int i=0;i<(int)addon.dllsToCopy.size();i++){
 		ofLogVerbose() << "adding addon dlls to bin: " << addon.dllsToCopy[i];
-		string dll = ofFilePath::join("addons/" + addon.name, addon.dllsToCopy[i]);
-		ofFile(ofFilePath::join(getOFRoot(),dll)).copyTo(ofFilePath::join(projectDir,"bin/"),false,true);
+		string dll = ofFilePath::join( addon.addonPath , addon.dllsToCopy[i]);
+		ofFile(dll).copyTo(ofFilePath::join(projectDir,"bin/"),false,true);
 	}
 
 	for(int i=0;i<(int)addon.cflags.size();i++){


### PR DESCRIPTION
These changes affect only projects generated for Visual Studio/Windows.

Proposes some changes that make it possible to use addons, and local addons which provide `.dlls` inside their libs. 

Dlls will need to be specified in `addon_config.mk` using the existing entry `ADDON_DLLS_TO_COPY`. Any `.dll` specified this way will be copied into a generated app's `bin` directory, so it can be found during the linker stage.

* also fixes an issue where the project generator would attempt to link against `.dll` files instead of just `.lib` files: when parsing addon libs, the updated project generator will skip any library files which are not `.lib` files for vs.

Otherwise, our current version of ofxAssimpModellLoader for example, will fail to link.