### PR TITLE
Removing using namespace std

### DIFF
--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -57,14 +57,14 @@ float               startTime;
 int                 nProjectsUpdated;
 int                 nProjectsCreated;
 
-string              directoryForRecursion;
-string              projectPath;
-string              ofPath;
-vector <string>     addons;
-vector <ofTargetPlatform>        targets;
-string              ofPathEnv;
-string              currentWorkingDirectory;
-string              templateName;
+std::string              directoryForRecursion;
+std::string              projectPath;
+std::string              ofPath;
+std::vector <std::string>     addons;
+std::vector <ofTargetPlatform>        targets;
+std::string              ofPathEnv;
+std::string              currentWorkingDirectory;
+std::string              templateName;
 
 bool busingEnvVar;
 bool bVerbose;
@@ -81,21 +81,21 @@ bool bDryRun;                           // do dry run (useful for debugging recu
 
 //-------------------------------------------
 void consoleSpace() {
-    cout << endl;
+    std::cout << std::endl;
 }
 
 
 bool printTemplates() {
     
-    cout << "getOFRoot() " << getOFRoot() << endl;
+    std::cout << "getOFRoot() " << getOFRoot() << std::endl;
     
     if(targets.size()>1){
-        vector<vector<baseProject::Template>> allPlatformsTemplates;
+	std::vector<std::vector<baseProject::Template>> allPlatformsTemplates;
         for(auto & target: targets){
             auto templates = getTargetProject(target)->listAvailableTemplates(getTargetString(target));
             allPlatformsTemplates.push_back(templates);
         }
-        set<baseProject::Template> commonTemplates;
+	std::set<baseProject::Template> commonTemplates;
         for(auto & templates: allPlatformsTemplates){
             for(auto & t: templates){
                 bool foundInAll = true;
@@ -139,10 +139,10 @@ bool printTemplates() {
     }
 }
 
-void addPlatforms(string value) {
+void addPlatforms(std::string value) {
 
     targets.clear();
-    vector < string > platforms = ofSplitString(value, ",", true, true);
+    std::vector < std::string > platforms = ofSplitString(value, ",", true, true);
 
     for (size_t i = 0; i < platforms.size(); i++) {
         if (platforms[i] == "linux") {
@@ -189,7 +189,7 @@ void addPlatforms(string value) {
 }
 
 
-bool isGoodProjectPath(string path) {
+bool isGoodProjectPath(std::string path) {
 
     ofDirectory dir(path);
     if (!dir.isDirectory()) {
@@ -214,7 +214,7 @@ bool isGoodProjectPath(string path) {
 
 }
 
-bool isGoodOFPath(string path) {
+bool isGoodOFPath(std::string path) {
 
     ofDirectory dir(path);
     if (!dir.isDirectory()) {
@@ -242,7 +242,7 @@ bool isGoodOFPath(string path) {
 
 
 
-void updateProject(string path, ofTargetPlatform target, bool bConsiderParameterAddons = true) {
+void updateProject(std::string path, ofTargetPlatform target, bool bConsiderParameterAddons = true) {
 
     // bConsiderParameterAddons = do we consider that the user could call update with a new set of addons
     // either we read the addons.make file, or we look at the parameter list.
@@ -267,7 +267,7 @@ void updateProject(string path, ofTargetPlatform target, bool bConsiderParameter
 }
 
 
-void recursiveUpdate(string path, ofTargetPlatform target) {
+void recursiveUpdate(std::string path, ofTargetPlatform target) {
     
     ofDirectory dir(path);
     
@@ -297,12 +297,12 @@ void printHelp(){
     
     consoleSpace();
     
-    string header = "";
+    std::string header = "";
     header += "\tprojectGenerator [options] pathName\n\n";
     header += "if pathName exists, project is updated\n";
     header += "if pathName doesn't exist, project is created\n";
     header += "(pathName must follow options, which can come in any order)";
-    cout << header << endl;
+    std::cout << header << std::endl;
     
     consoleSpace();
     
@@ -310,7 +310,7 @@ void printHelp(){
     
     consoleSpace();
     
-    string footer = "";
+    std::string footer = "";
     footer += "examples:\n\n";
     footer +=
     STRINGIFY(
@@ -332,7 +332,7 @@ void printHelp(){
               );
     footer += "\n";
     footer += "(create / update an example with addons)";
-    cout << footer << endl;
+    std::cout << footer << std::endl;
     
     consoleSpace();
 }
@@ -356,7 +356,7 @@ int main(int argc, char* argv[]){
     startTime = 0;
     nProjectsUpdated = 0;
     nProjectsCreated = 0;
-    string projectName = "";
+    std::string projectName = "";
     projectPath = "";
     templateName = "";
     
@@ -397,7 +397,7 @@ int main(int argc, char* argv[]){
     
     if (options[PLATFORMS].count() > 0){
         if (options[PLATFORMS].arg != NULL){
-            string platformString(options[PLATFORMS].arg);
+	    std::string platformString(options[PLATFORMS].arg);
             addPlatforms(platformString);
         }
     }
@@ -405,7 +405,7 @@ int main(int argc, char* argv[]){
     if (options[ADDONS].count() > 0){
         bAddonsPassedIn = true; // could be empty
         if (options[ADDONS].arg != NULL){
-            string addonsString(options[ADDONS].arg);
+	    std::string addonsString(options[ADDONS].arg);
             addons = ofSplitString(addonsString, ",", true, true);
         }
     }
@@ -414,14 +414,14 @@ int main(int argc, char* argv[]){
     
     if (options[OFPATH].count() > 0){
         if (options[OFPATH].arg != NULL){
-            string ofPathString(options[OFPATH].arg);
+	    std::string ofPathString(options[OFPATH].arg);
             ofPath = ofPathString;
         }
     }
     
     if (options[TEMPLATE].count() > 0){
         if (options[TEMPLATE].arg != NULL){
-            string templateString(options[TEMPLATE].arg);
+	    std::string templateString(options[TEMPLATE].arg);
             templateName = templateString;
         }
     }
@@ -444,7 +444,7 @@ int main(int argc, char* argv[]){
     char* pPath;
     pPath = getenv("PG_OF_PATH");
     if (pPath != NULL) {
-        ofPathEnv = string(pPath);
+        ofPathEnv = std::string(pPath);
     }
     
     if (ofPath == "" && ofPathEnv != "") {
@@ -629,10 +629,10 @@ int main(int argc, char* argv[]){
 
     consoleSpace();
     float elapsedTime = ofGetElapsedTimef() - startTime;
-    if (nProjectsCreated > 0) cout << nProjectsCreated << " project created ";
-    if (nProjectsUpdated == 1)cout << nProjectsUpdated << " project updated ";
-    if (nProjectsUpdated > 1) cout << nProjectsUpdated << " projects updated ";
-    ofLogNotice() << "in " << elapsedTime << " seconds" << endl;
+    if (nProjectsCreated > 0) std::cout << nProjectsCreated << " project created ";
+    if (nProjectsUpdated == 1) std::cout << nProjectsUpdated << " project updated ";
+    if (nProjectsUpdated > 1) std::cout << nProjectsUpdated << " projects updated ";
+    ofLogNotice() << "in " << elapsedTime << " seconds" << std::endl;
     consoleSpace();
 
 	

--- a/ofxProjectGenerator/src/addons/ofAddon.h
+++ b/ofxProjectGenerator/src/addons/ofAddon.h
@@ -86,9 +86,9 @@ private:
     void parseVariableValue(std::string variable, std::string value, bool addToValue, std::string line, int lineNum);
     void addReplaceString(std::string & variable, std::string value, bool addToVariable);
     void addReplaceStringVector(std::vector<std::string> & variable, std::string value, std::string prefix, bool addToVariable);
-	void addReplaceStringVector(vector<LibraryBinary> & variable, string value, string prefix, bool addToVariable);
+	void addReplaceStringVector(std::vector<LibraryBinary> & variable, std::string value, std::string prefix, bool addToVariable);
     void exclude(std::vector<std::string> & variable, std::vector<std::string> exclusions);
-	void exclude(vector<LibraryBinary> & variable, vector<string> exclusions);
+	void exclude(std::vector<LibraryBinary> & variable, std::vector<std::string> exclusions);
     ConfigParseState stateFromString(std::string name);
     std::string stateName(ConfigParseState state);
     bool checkCorrectVariable(std::string variable, ConfigParseState state);

--- a/ofxProjectGenerator/src/projects/CBLinuxProject.cpp
+++ b/ofxProjectGenerator/src/projects/CBLinuxProject.cpp
@@ -10,15 +10,15 @@
 #include "ofLog.h"
 #include "Utils.h"
 
-string CBLinuxProject::LOG_NAME = "CBLinuxProject";
+std::string CBLinuxProject::LOG_NAME = "CBLinuxProject";
 
 bool CBLinuxProject::createProjectFile(){
 	ofDirectory dir(projectDir);
 	if(!dir.exists()) dir.create(true);
 
     ofFile project(ofFilePath::join(projectDir, projectName + ".cbp"));
-    string src =  ofFilePath::join(templatePath,"emptyExample_" + target + ".cbp");
-    string dst = project.path();
+    std::string src =  ofFilePath::join(templatePath,"emptyExample_" + target + ".cbp");
+    std::string dst = project.path();
     bool ret;
 
     if(!project.exists()){
@@ -68,9 +68,9 @@ bool CBLinuxProject::createProjectFile(){
 
 
     // handle the relative roots.
-    string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
+    std::string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
     if (relRoot != "../../../"){
-        string relPath2 = relRoot;
+        std::string relPath2 = relRoot;
         relPath2.erase(relPath2.end()-1);
         findandreplaceInTexfile(projectDir + "Makefile", "../../..", relPath2);
         findandreplaceInTexfile(projectDir + "config.make", "../../..", relPath2);

--- a/ofxProjectGenerator/src/projects/CBWinProject.cpp
+++ b/ofxProjectGenerator/src/projects/CBWinProject.cpp
@@ -10,11 +10,11 @@
 #include "ofLog.h"
 #include "Utils.h"
 
-string CBWinProject::LOG_NAME = "CBWinProject";
+std::string CBWinProject::LOG_NAME = "CBWinProject";
 bool CBWinProject::createProjectFile(){
 
-    string project = projectDir + projectName + ".cbp";
-    string workspace = projectDir + projectName + ".workspace";
+    std::string project = projectDir + projectName + ".cbp";
+    std::string workspace = projectDir + projectName + ".workspace";
 
 
 	ofFile::copyFromTo(ofFilePath::join(templatePath,"emptyExample.cbp"),project, false, true);
@@ -23,11 +23,11 @@ bool CBWinProject::createProjectFile(){
 	ofFile::copyFromTo(ofFilePath::join(templatePath,"icon.rc"), projectDir + "icon.rc", false, true);
 
     //let's do some renaming:
-    string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
+    std::string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
 
     if (relRoot != "../../../"){
 
-        string relRootWindows = relRoot;
+        std::string relRootWindows = relRoot;
         // let's make it windows friendly:
         for(int i = 0; i < relRootWindows.length(); i++) {
             if( relRootWindows[i] == '/' )
@@ -70,14 +70,14 @@ bool CBWinProject::saveProjectFile(){
     return doc.save_file((projectDir + projectName + ".cbp").c_str());
 }
 
-void CBWinProject::addSrc(string srcName, string folder, SrcType type){
+void CBWinProject::addSrc(std::string srcName, std::string folder, SrcType type){
 	pugi::xml_node node = appendValue(doc, "Unit", "filename", srcName);
 	if(!node.empty()){
 		node.child("Option").attribute("virtualFolder").set_value(folder.c_str());
 	}
 }
 
-void CBWinProject::addInclude(string includeName){
+void CBWinProject::addInclude(std::string includeName){
     ofLogNotice() << "adding include " << includeName;
     appendValue(doc, "Add", "directory", includeName);
 }
@@ -88,10 +88,10 @@ void CBWinProject::addLibrary(const LibraryBinary & lib){
     // this is because we might need to say libosc, then ws2_32
 }
 
-string CBWinProject::getName(){
+std::string CBWinProject::getName(){
 	return projectName;
 }
 
-string CBWinProject::getPath(){
+std::string CBWinProject::getPath(){
 	return projectDir;
 }

--- a/ofxProjectGenerator/src/projects/androidStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/androidStudioProject.cpp
@@ -4,9 +4,9 @@
 #include "Utils.h"
 #include <regex>
 
-string AndroidStudioProject::LOG_NAME = "AndroidStudioProject";
+std::string AndroidStudioProject::LOG_NAME = "AndroidStudioProject";
 
-AndroidStudioProject::AndroidStudioProject(string target)
+AndroidStudioProject::AndroidStudioProject(std::string target)
     : baseProject(target){
 
 }
@@ -14,7 +14,7 @@ AndroidStudioProject::AndroidStudioProject(string target)
 bool AndroidStudioProject::createProjectFile(){
     
     // Make sure project name doesn't include "-"
-    string packageName = projectName;
+    std::string packageName = projectName;
     ofStringReplace(packageName, "-", "");
     
     ofDirectory dir(projectDir);
@@ -22,8 +22,8 @@ bool AndroidStudioProject::createProjectFile(){
 
     // build.gradle
     ofFile gradleFile(ofFilePath::join(projectDir, "build.gradle"));
-    string src = ofFilePath::join(templatePath,"build.gradle");
-    string dst = gradleFile.path();
+    std::string src = ofFilePath::join(templatePath,"build.gradle");
+    std::string dst = gradleFile.path();
 
     if(!gradleFile.exists()){
         if(!ofFile::copyFromTo(src,dst)){
@@ -109,8 +109,8 @@ bool AndroidStudioProject::createProjectFile(){
     // srcJava folder
     ofDirectory(ofFilePath::join(templatePath,"srcJava")).copyTo(ofFilePath::join(projectDir,"srcJava"));
     
-    string from = ofFilePath::join(projectDir,"srcJava/cc/openframeworks/APP_NAME");
-    string to = ofFilePath::join(projectDir,"srcJava/cc/openframeworks/"+projectName);
+    std::string from = ofFilePath::join(projectDir,"srcJava/cc/openFrameworks/APP_NAME");
+    std::string to = ofFilePath::join(projectDir,"srcJava/cc/openFrameworks/"+projectName);
     
     findandreplaceInTexfile(ofFilePath::join(from,"OFActivity.java"), "TEMPLATE_APP_NAME", projectName);
     ofDirectory(from).moveTo(to, true, true);

--- a/ofxProjectGenerator/src/projects/androidStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/androidStudioProject.cpp
@@ -109,8 +109,8 @@ bool AndroidStudioProject::createProjectFile(){
     // srcJava folder
     ofDirectory(ofFilePath::join(templatePath,"srcJava")).copyTo(ofFilePath::join(projectDir,"srcJava"));
     
-    std::string from = ofFilePath::join(projectDir,"srcJava/cc/openFrameworks/APP_NAME");
-    std::string to = ofFilePath::join(projectDir,"srcJava/cc/openFrameworks/"+projectName);
+    std::string from = ofFilePath::join(projectDir,"srcJava/cc/openframeworks/APP_NAME");
+    std::string to = ofFilePath::join(projectDir,"srcJava/cc/openframeworks/"+projectName);
     
     findandreplaceInTexfile(ofFilePath::join(from,"OFActivity.java"), "TEMPLATE_APP_NAME", projectName);
     ofDirectory(from).moveTo(to, true, true);

--- a/ofxProjectGenerator/src/projects/baseProject.h
+++ b/ofxProjectGenerator/src/projects/baseProject.h
@@ -2,8 +2,6 @@
 
 #pragma once
 
-#include <set>
-
 #include "ofAddon.h"
 #include "ofConstants.h"
 #include "ofFileUtils.h"
@@ -29,7 +27,7 @@ public:
     struct Template{
         ofDirectory dir;
         std::string name;
-        vector<std::string> platforms;
+	std::vector<std::string> platforms;
         std::string description;
         std::map<std::filesystem::path, std::filesystem::path> renames;
         bool operator<(const Template & other) const{
@@ -73,7 +71,7 @@ public:
     std::string getName() { return projectName;}
     std::string getPath() { return projectDir; }
 
-	vector<Template> listAvailableTemplates(std::string target);
+    std::vector<Template> listAvailableTemplates(std::string target);
     std::unique_ptr<baseProject::Template> parseTemplate(const ofDirectory & templateDir);
 	virtual std::string getPlatformTemplateDir();
 
@@ -88,7 +86,7 @@ public:
 protected:
     void recursiveCopyContents(const ofDirectory & srcDir, ofDirectory & destDir);
 
-    vector<ofAddon> addons;
+    std::vector<ofAddon> addons;
 };
 
 

--- a/ofxProjectGenerator/src/projects/qtcreatorproject.cpp
+++ b/ofxProjectGenerator/src/projects/qtcreatorproject.cpp
@@ -4,9 +4,9 @@
 #include "Utils.h"
 #include <regex>
 
-string QtCreatorProject::LOG_NAME = "QtCreatorProject";
+std::string QtCreatorProject::LOG_NAME = "QtCreatorProject";
 
-QtCreatorProject::QtCreatorProject(string target)
+QtCreatorProject::QtCreatorProject(std::string target)
     : baseProject(target){
 
 }
@@ -16,8 +16,8 @@ bool QtCreatorProject::createProjectFile(){
     if(!dir.exists()) dir.create(true);
 
     ofFile project(ofFilePath::join(projectDir, projectName + ".qbs"));
-    string src = ofFilePath::join(templatePath,"qtcreator.qbs");
-    string dst = project.path();
+    std::string src = ofFilePath::join(templatePath,"qtcreator.qbs");
+    std::string dst = project.path();
 
     if(!project.exists()){
         if(!ofFile::copyFromTo(src,dst)){
@@ -50,9 +50,9 @@ bool QtCreatorProject::createProjectFile(){
 
 
     // handle the relative roots.
-    string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
+    std::string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
     if (relRoot != "../../../"){
-        string relPath2 = relRoot;
+        std::string relPath2 = relRoot;
         relPath2.erase(relPath2.end()-1);
         findandreplaceInTexfile(projectDir + "qtcreator.qbs", "../../..", relPath2);
         findandreplaceInTexfile(projectDir + "Makefile", "../../..", relPath2);

--- a/ofxProjectGenerator/src/projects/qtcreatorproject.h
+++ b/ofxProjectGenerator/src/projects/qtcreatorproject.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "baseProject.h"
+#include <set>
 
 class QtCreatorProject : public baseProject
 {

--- a/ofxProjectGenerator/src/projects/visualStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.cpp
@@ -4,15 +4,15 @@
 #include "visualStudioProject.h"
 #include "Utils.h"
 
-string visualStudioProject::LOG_NAME = "visualStudioProjectFile";
+std::string visualStudioProject::LOG_NAME = "visualStudioProjectFile";
 
 
 bool visualStudioProject::createProjectFile(){
 
-    string project = ofFilePath::join(projectDir,projectName + ".vcxproj");
-    string user = ofFilePath::join(projectDir,projectName + ".vcxproj.user");
-    string solution = ofFilePath::join(projectDir,projectName + ".sln");
-	string filters = ofFilePath::join(projectDir, projectName + ".vcxproj.filters");
+    std::string project = ofFilePath::join(projectDir,projectName + ".vcxproj");
+    std::string user = ofFilePath::join(projectDir,projectName + ".vcxproj.user");
+    std::string solution = ofFilePath::join(projectDir,projectName + ".sln");
+    std::string filters = ofFilePath::join(projectDir, projectName + ".vcxproj.filters");
 
     ofFile::copyFromTo(ofFilePath::join(templatePath,"emptyExample.vcxproj"),project,false, true);
     ofFile::copyFromTo(ofFilePath::join(templatePath,"emptyExample.vcxproj.user"),user, false, true);
@@ -21,7 +21,7 @@ bool visualStudioProject::createProjectFile(){
 	ofFile::copyFromTo(ofFilePath::join(templatePath,"icon.rc"), projectDir + "icon.rc", false, true);
 
 	ofFile filterFile(filters);
-	string temp = filterFile.readToBuffer();
+	std::string temp = filterFile.readToBuffer();
 	pugi::xml_parse_result result = filterXmlDoc.load(temp.c_str());
 	if (result.status==pugi::status_ok) ofLogVerbose() << "loaded filter ";
 	else ofLogVerbose() << "problem loading filter ";
@@ -30,10 +30,10 @@ bool visualStudioProject::createProjectFile(){
     findandreplaceInTexfile(user,"emptyExample",projectName);
     findandreplaceInTexfile(project,"emptyExample",projectName);
 
-    string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
+    std::string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
     if (relRoot != "../../../"){
 
-        string relRootWindows = relRoot;
+	std::string relRootWindows = relRoot;
         // let's make it windows friendly:
         for(int i = 0; i < relRootWindows.length(); i++) {
             if( relRootWindows[i] == '/' )
@@ -67,22 +67,22 @@ bool visualStudioProject::loadProjectFile(){
 
 bool visualStudioProject::saveProjectFile(){
 
-	string filters = projectDir + projectName + ".vcxproj.filters";
-	filterXmlDoc.save_file(filters.c_str());
+    std::string filters = projectDir + projectName + ".vcxproj.filters";
+    filterXmlDoc.save_file(filters.c_str());
 
 
     return doc.save_file((projectDir + projectName + ".vcxproj").c_str());
 }
 
 
-void visualStudioProject::appendFilter(string folderName){
+void visualStudioProject::appendFilter(std::string folderName){
 
 
     fixSlashOrder(folderName);
 
-	string uuid = generateUUID(folderName);
+	 std::string uuid = generateUUID(folderName);
 
-	string tag = "//ItemGroup[Filter]/Filter[@Include=\"" + folderName + "\"]";
+	 std::string tag = "//ItemGroup[Filter]/Filter[@Include=\"" + folderName + "\"]";
 	 pugi::xpath_node_set set = filterXmlDoc.select_nodes(tag.c_str());
 	 if (set.size() > 0){
 
@@ -102,18 +102,18 @@ void visualStudioProject::appendFilter(string folderName){
 
 		 //d8376475-7454-4a24-b08a-aac121d3ad6f
 
-		 string uuidAltered = "{" + uuid + "}";
+		 std::string uuidAltered = "{" + uuid + "}";
 		 nodeAdded2.append_child(pugi::node_pcdata).set_value(uuidAltered.c_str());
 	 }
 }
 
-void visualStudioProject::addSrc(string srcFile, string folder, SrcType type){
+void visualStudioProject::addSrc(std::string srcFile, std::string folder, SrcType type){
 
     fixSlashOrder(folder);
     fixSlashOrder(srcFile);
 
-	vector < string > folderSubNames = ofSplitString(folder, "\\");
-	string folderName = "";
+	std::vector < std::string > folderSubNames = ofSplitString(folder, "\\");
+	std::string folderName = "";
 	for (int i = 0; i < folderSubNames.size(); i++){
 		if (i != 0) folderName += "\\";
 		folderName += folderSubNames[i];
@@ -200,7 +200,7 @@ void visualStudioProject::addSrc(string srcFile, string folder, SrcType type){
 
 }
 
-void visualStudioProject::addInclude(string includeName){
+void visualStudioProject::addInclude(std::string includeName){
 
 
     fixSlashOrder(includeName);
@@ -208,8 +208,8 @@ void visualStudioProject::addInclude(string includeName){
     pugi::xpath_node_set source = doc.select_nodes("//ClCompile/AdditionalIncludeDirectories");
     for (pugi::xpath_node_set::const_iterator it = source.begin(); it != source.end(); ++it){
         pugi::xpath_node node = *it;
-        string includes = node.node().first_child().value();
-        vector < string > strings = ofSplitString(includes, ";");
+        std::string includes = node.node().first_child().value();
+        std::vector < std::string > strings = ofSplitString(includes, ";");
         bool bAdd = true;
         for (int i = 0; i < (int)strings.size(); i++){
             if (strings[i].compare(includeName) == 0){
@@ -218,7 +218,7 @@ void visualStudioProject::addInclude(string includeName){
         }
         if (bAdd == true){
             strings.push_back(includeName);
-            string includesNew = unsplitString(strings, ";");
+            std::string includesNew = unsplitString(strings, ";");
             node.node().first_child().set_value(includesNew.c_str());
         }
 
@@ -228,8 +228,8 @@ void visualStudioProject::addInclude(string includeName){
 
 void addLibraryPath(const pugi::xpath_node_set & nodes, std::string libFolder) {
 	for (auto & node : nodes) {
-		string includes = node.node().first_child().value();
-		vector < string > strings = ofSplitString(includes, ";");
+		std::string includes = node.node().first_child().value();
+		std::vector < std::string > strings = ofSplitString(includes, ";");
 		bool bAdd = true;
 		for (int i = 0; i < (int)strings.size(); i++) {
 			if (strings[i].compare(libFolder) == 0) {
@@ -238,7 +238,7 @@ void addLibraryPath(const pugi::xpath_node_set & nodes, std::string libFolder) {
 		}
 		if (bAdd == true) {
 			strings.push_back(libFolder);
-			string libPathsNew = unsplitString(strings, ";");
+			std::string libPathsNew = unsplitString(strings, ";");
 			node.node().first_child().set_value(libPathsNew.c_str());
 		}
 	}
@@ -248,8 +248,8 @@ void addLibraryName(const pugi::xpath_node_set & nodes, std::string libName) {
 
 	for (auto & node : nodes) {
 
-		string includes = node.node().first_child().value();
-		vector < string > strings = ofSplitString(includes, ";");
+		std::string includes = node.node().first_child().value();
+		std::vector < std::string > strings = ofSplitString(includes, ";");
 		bool bAdd = true;
 		for (int i = 0; i < (int)strings.size(); i++) {
 			if (strings[i].compare(libName) == 0) {
@@ -259,7 +259,7 @@ void addLibraryName(const pugi::xpath_node_set & nodes, std::string libName) {
 
 		if (bAdd == true) {
 			strings.push_back(libName);
-			string libsNew = unsplitString(strings, ";");
+			std::string libsNew = unsplitString(strings, ";");
 			node.node().first_child().set_value(libsNew.c_str());
 		}
 	}
@@ -271,18 +271,18 @@ void visualStudioProject::addLibrary(const LibraryBinary & lib){
 
     // ok first, split path and library name.
     size_t found = libraryName.find_last_of("\\");
-    string libFolder = libraryName.substr(0,found);
-    string libName = libraryName.substr(found+1);
+    std::string libFolder = libraryName.substr(0,found);
+    std::string libName = libraryName.substr(found+1);
 
-	string libBaseName;
-	string libExtension;
+    std::string libBaseName;
+    std::string libExtension;
 
 	splitFromLast( libName, ".", libBaseName, libExtension );
 
 	// ---------| invariant: libExtension is `lib`
 
     // paths for libraries
-	string linkPath;
+	std::string linkPath;
 	if (!lib.target.empty() && !lib.arch.empty()) {
 		linkPath = "//ItemDefinitionGroup[contains(@Condition,'" + lib.target + "') and contains(@Condition,'" + lib.arch + "')]/Link/";
 	}
@@ -307,7 +307,7 @@ void visualStudioProject::addLibrary(const LibraryBinary & lib){
 
 }
 
-void visualStudioProject::addCFLAG(string cflag, LibType libType){
+void visualStudioProject::addCFLAG(std::string cflag, LibType libType){
 	pugi::xpath_node_set items = doc.select_nodes("//ItemDefinitionGroup");
 	for(int i=0;i<items.size();i++){
 		pugi::xml_node additionalOptions;
@@ -324,13 +324,13 @@ void visualStudioProject::addCFLAG(string cflag, LibType libType){
 		if(!additionalOptions){
 			items[i].node().child("ClCompile").append_child("AdditionalOptions").append_child(pugi::node_pcdata).set_value(cflag.c_str());
 		}else{
-			additionalOptions.set_value((string(additionalOptions.value()) + " " + cflag).c_str());
+			additionalOptions.set_value((std::string(additionalOptions.value()) + " " + cflag).c_str());
 		}
 	}
 
 }
 
-void visualStudioProject::addCPPFLAG(string cppflag, LibType libType){
+void visualStudioProject::addCPPFLAG(std::string cppflag, LibType libType){
 	pugi::xpath_node_set items = doc.select_nodes("//ItemDefinitionGroup");
 	for(int i=0;i<items.size();i++){
 		pugi::xml_node additionalOptions;
@@ -347,7 +347,7 @@ void visualStudioProject::addCPPFLAG(string cppflag, LibType libType){
 		if(!additionalOptions){
 			items[i].node().child("ClCompile").append_child("AdditionalOptions").append_child(pugi::node_pcdata).set_value(cppflag.c_str());
 		}else{
-			additionalOptions.set_value((string(additionalOptions.value()) + " " + cppflag).c_str());
+			additionalOptions.set_value((std::string(additionalOptions.value()) + " " + cppflag).c_str());
 		}
 	}
 
@@ -373,7 +373,7 @@ void visualStudioProject::addDefine(std::string define, LibType libType)
 			items[i].node().child("ClCompile").append_child("PreprocessorDefinitions").append_child(pugi::node_pcdata).set_value(define.c_str());
 		}
 		else {
-			additionalOptions.set_value((string(additionalOptions.value()) + " " + define).c_str());
+			additionalOptions.set_value((std::string(additionalOptions.value()) + " " + define).c_str());
 		}
 	}
 }
@@ -427,7 +427,7 @@ void visualStudioProject::addAddon(ofAddon & addon){
 
 	for(int i=0;i<(int)addon.dllsToCopy.size();i++){
 		ofLogVerbose() << "adding addon dlls to bin: " << addon.dllsToCopy[i];
-		string dll = std::filesystem::absolute(addon.dllsToCopy[i], addon.addonPath).string();
+		std::string dll = std::filesystem::absolute(addon.dllsToCopy[i], addon.addonPath).string();
 		ofFile(dll).copyTo(ofFilePath::join(projectDir,"bin/"),false,true);
 	}
 

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -235,22 +235,22 @@ xcodeProject::xcodeProject(std::string target)
 
 void xcodeProject::saveScheme(){
 
-	string schemeFolder = projectDir + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/";
+    std::string schemeFolder = projectDir + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/";
     if (ofDirectory::doesDirectoryExist(schemeFolder)){
         ofDirectory::removeDirectory(schemeFolder, true);
     }
 	ofDirectory::createDirectory(schemeFolder, false, true);
     
 	if(target=="osx"){
-		string schemeToD = projectDir  + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/" + projectName + " Debug.xcscheme";
+		std::string schemeToD = projectDir  + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/" + projectName + " Debug.xcscheme";
 		ofFile::copyFromTo(ofFilePath::join(templatePath, "emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample Debug.xcscheme"), schemeToD);
 	
-		string schemeToR = projectDir  + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/" + projectName + " Release.xcscheme";
+		std::string schemeToR = projectDir  + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/" + projectName + " Release.xcscheme";
 		ofFile::copyFromTo(ofFilePath::join(templatePath, "emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample Release.xcscheme"), schemeToR);
 	    findandreplaceInTexfile(schemeToD, "emptyExample", projectName);
 	    findandreplaceInTexfile(schemeToR, "emptyExample", projectName);
 	}else{
-		string schemeTo = projectDir  + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/" + projectName + ".xcscheme";
+		std::string schemeTo = projectDir  + projectName + ".xcodeproj" + "/xcshareddata/xcschemes/" + projectName + ".xcscheme";
 		ofFile::copyFromTo(ofFilePath::join(templatePath, "emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample.xcscheme"), schemeTo);
 	    findandreplaceInTexfile(schemeTo, "emptyExample", projectName);
 	}
@@ -264,8 +264,8 @@ void xcodeProject::saveScheme(){
 
 void xcodeProject::saveWorkspaceXML(){
 
-	string workspaceFolder = projectDir + projectName + ".xcodeproj" + "/project.xcworkspace/";
-	string xcodeProjectWorkspace = workspaceFolder + "contents.xcworkspacedata";    
+    std::string workspaceFolder = projectDir + projectName + ".xcodeproj" + "/project.xcworkspace/";
+    std::string xcodeProjectWorkspace = workspaceFolder + "contents.xcworkspacedata";    
 
     
     if (ofFile::doesFileExist(xcodeProjectWorkspace)){
@@ -283,12 +283,12 @@ void xcodeProject::saveWorkspaceXML(){
 }
 
 void xcodeProject::saveMakefile(){
-    string makefile = ofFilePath::join(projectDir,"Makefile");
+    std::string makefile = ofFilePath::join(projectDir,"Makefile");
     if(!ofFile(makefile).exists()){
         ofFile::copyFromTo(ofFilePath::join(templatePath, "Makefile"), makefile, true, true);
     }
 
-    string configmake = ofFilePath::join(projectDir,"config.make");
+    std::string configmake = ofFilePath::join(projectDir,"config.make");
     if(!ofFile(configmake).exists()){
         ofFile::copyFromTo(ofFilePath::join(templatePath, "config.make"), configmake, true, true);
     }
@@ -298,7 +298,7 @@ void xcodeProject::saveMakefile(){
 bool xcodeProject::createProjectFile(){
     // todo: some error checking.
 
-    string xcodeProject = ofFilePath::join(projectDir , projectName + ".xcodeproj");
+    std::string xcodeProject = ofFilePath::join(projectDir , projectName + ".xcodeproj");
     
     if (ofDirectory::doesDirectoryExist(xcodeProject)){
         ofDirectory::removeDirectory(xcodeProject, true);
@@ -365,9 +365,9 @@ bool xcodeProject::createProjectFile(){
     }
 
     // make everything relative the right way.
-    string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
+    std::string relRoot = getOFRelPath(ofFilePath::removeTrailingSlash(projectDir));
     if (relRoot != "../../../"){
-        string relPath2 = relRoot;
+        std::string relPath2 = relRoot;
         relPath2.erase(relPath2.end()-1);
         findandreplaceInTexfile(projectDir + projectName + ".xcodeproj/project.pbxproj", "../../..", relPath2);
         //findandreplaceInTexfile(projectDir + "Project.xcconfig", "../../../", relRoot);
@@ -388,7 +388,7 @@ void xcodeProject::renameProject(){
     pugi::xpath_node_set uuidSet = doc.select_nodes("//string[contains(.,'emptyExample')]");
     for (pugi::xpath_node_set::const_iterator it = uuidSet.begin(); it != uuidSet.end(); ++it){
         pugi::xpath_node node = *it;
-        string val = it->node().first_child().value();
+        std::string val = it->node().first_child().value();
         findandreplace(val, "emptyExample",  projectName);
         it->node().first_child().set_value(val.c_str());
     }
@@ -396,7 +396,7 @@ void xcodeProject::renameProject(){
 
 
 bool xcodeProject::loadProjectFile(){
-    string fileName = projectDir + projectName + ".xcodeproj/project.pbxproj";
+    std::string fileName = projectDir + projectName + ".xcodeproj/project.pbxproj";
     renameProject();
     pugi::xml_parse_result result = doc.load_file(ofToDataPath(fileName).c_str());
 
@@ -416,7 +416,7 @@ bool xcodeProject::saveProjectFile(){
 
     // save the project out:
 
-    string fileName = projectDir + projectName + ".xcodeproj/project.pbxproj";
+    std::string fileName = projectDir + projectName + ".xcodeproj/project.pbxproj";
     bool bOk =  doc.save_file(ofToDataPath(fileName).c_str());
 
     return bOk;
@@ -425,7 +425,7 @@ bool xcodeProject::saveProjectFile(){
 
 
 
-bool xcodeProject::findArrayForUUID(string UUID, pugi::xml_node & nodeMe){
+bool xcodeProject::findArrayForUUID(std::string UUID, pugi::xml_node & nodeMe){
     char query[255];
     sprintf(query, "//string[contains(.,'%s')]", UUID.c_str());
     pugi::xpath_node_set uuidSet = doc.select_nodes(query);
@@ -443,7 +443,7 @@ bool xcodeProject::findArrayForUUID(string UUID, pugi::xml_node & nodeMe){
 
 
 
-pugi::xml_node xcodeProject::findOrMakeFolderSet(pugi::xml_node nodeToAddTo, vector < string > & folders, string pathForHash){
+pugi::xml_node xcodeProject::findOrMakeFolderSet(pugi::xml_node nodeToAddTo, std::vector < std::string > & folders, std::string pathForHash){
 
 
 
@@ -454,7 +454,7 @@ pugi::xml_node xcodeProject::findOrMakeFolderSet(pugi::xml_node nodeToAddTo, vec
 
     bool bAnyNodeWithThisName = false;
     pugi::xml_node nodeWithThisName;
-    string name = folders[0];
+    std::string name = folders[0];
 
 
     for (pugi::xpath_node_set::const_iterator it = array.begin(); it != array.end(); ++it){
@@ -499,10 +499,10 @@ pugi::xml_node xcodeProject::findOrMakeFolderSet(pugi::xml_node nodeToAddTo, vec
 
         pathForHash += "/" + folders[0];
 
-        string UUID = generateUUID(pathForHash);
+        std::string UUID = generateUUID(pathForHash);
 
         // add a new node
-        string PBXGroupStr = string(PBXGroup);
+        std::string PBXGroupStr = std::string(PBXGroup);
         findandreplace( PBXGroupStr, "GROUPUUID", UUID);
         findandreplace( PBXGroupStr, "GROUPNAME", folders[0]);
 
@@ -540,7 +540,7 @@ pugi::xml_node xcodeProject::findOrMakeFolderSet(pugi::xml_node nodeToAddTo, vec
 
 // todo: frameworks
 //
-void xcodeProject::addFramework(string name, string path, string folder){
+void xcodeProject::addFramework(std::string name, std::string path, std::string folder){
     
     // name = name of the framework
     // path = the full path (w name) of this framework
@@ -556,11 +556,11 @@ void xcodeProject::addFramework(string name, string path, string folder){
     
     // encoding may be messing up for frameworks... so I switched to a pbx file ref without encoding fields
     
-    string pbxfileref = string(PBXFileReferenceWithoutEncoding);
+    std::string pbxfileref = std::string(PBXFileReferenceWithoutEncoding);
     
     // make a uuid for the framework file.
     
-    string UUID = generateUUID( name );
+    std::string UUID = generateUUID( name );
 
     findandreplace( pbxfileref, "FILEUUID", UUID);
     findandreplace( pbxfileref, "FILENAME", name);
@@ -578,8 +578,8 @@ void xcodeProject::addFramework(string name, string path, string folder){
     
     // files need build refs, here we make 2....
 
-    string buildUUID = generateUUID(name + "-build");
-    string pbxbuildfile = string(PBXBuildFile);
+    std::string buildUUID = generateUUID(name + "-build");
+    std::string pbxbuildfile = std::string(PBXBuildFile);
     findandreplace( pbxbuildfile, "FILEUUID", UUID);
     findandreplace( pbxbuildfile, "BUILDUUID", buildUUID);
     fileRefDoc.load_buffer(pbxbuildfile.c_str(), strlen(pbxbuildfile.c_str()));
@@ -605,8 +605,8 @@ void xcodeProject::addFramework(string name, string path, string folder){
     if (folder.size() != 0 && !ofIsStringInString(path, "/System/Library/Frameworks")
         && target != "ios"){
         
-        string buildUUID2 = generateUUID(name + "-build2");
-        pbxbuildfile = string(PBXBuildFile);
+        std::string buildUUID2 = generateUUID(name + "-build2");
+        pbxbuildfile = std::string(PBXBuildFile);
         findandreplace( pbxbuildfile, "FILEUUID", UUID);
         findandreplace( pbxbuildfile, "BUILDUUID", buildUUID2);
         fileRefDoc.load_buffer(pbxbuildfile.c_str(), strlen(pbxbuildfile.c_str()));
@@ -620,8 +620,8 @@ void xcodeProject::addFramework(string name, string path, string folder){
     
     // now, we get the path for this framework without the name
 
-    string pathWithoutName;
-    vector < string > pathSplit = ofSplitString(path, "/");
+    std::string pathWithoutName;
+    std::vector < std::string > pathSplit = ofSplitString(path, "/");
     for (int i = 0; i < pathSplit.size()-1; i++){
         if (i != 0) pathWithoutName += "/";
         pathWithoutName += pathSplit[i];
@@ -643,11 +643,11 @@ void xcodeProject::addFramework(string name, string path, string folder){
     
     if (folder.size() > 0 && !ofIsStringInString(folder, "/System/Library/Frameworks")){
         
-        vector < string > folders = ofSplitString(folder, "/", true);
+        std::vector < std::string > folders = ofSplitString(folder, "/", true);
         
         if (folders.size() > 1){
             if (folders[0] == "src"){
-                string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
                 
                 folders.erase(folders.begin());
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
@@ -655,7 +655,7 @@ void xcodeProject::addFramework(string name, string path, string folder){
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
                 
             } else if (folders[0] == "addons"){
-                string xmlStr = "//key[contains(.,'"+addonUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+addonUUID+"')]/following-sibling::node()[1]";
                 
                 folders.erase(folders.begin());
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
@@ -664,7 +664,7 @@ void xcodeProject::addFramework(string name, string path, string folder){
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
                 
             } else {
-                string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
                 
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
                 
@@ -678,7 +678,7 @@ void xcodeProject::addFramework(string name, string path, string folder){
         
         
         pugi::xml_node array;
-		string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+        std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
         pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
         node.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
         //nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
@@ -697,16 +697,16 @@ void xcodeProject::addFramework(string name, string path, string folder){
 
 
 
-void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
+void xcodeProject::addSrc(std::string srcFile, std::string folder, SrcType type){
 
-    string buildUUID;
+    std::string buildUUID;
 
     //-----------------------------------------------------------------
     // find the extension for the file that's passed in.
     //-----------------------------------------------------------------
 
     size_t found = srcFile.find_last_of(".");
-    string ext = srcFile.substr(found+1);
+    std::string ext = srcFile.substr(found+1);
 
     //-----------------------------------------------------------------
     // based on the extension make some choices about what to do:
@@ -715,7 +715,7 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
     bool addToResources = true;
     bool addToBuild = true;
     bool addToBuildResource = false; 
-    string fileKind = "file";
+    std::string fileKind = "file";
     bool bAddFolder = true;
 
     if(type==DEFAULT){
@@ -779,15 +779,15 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
     // (A) make a FILE REF
     //-----------------------------------------------------------------
 
-    string pbxfileref = string(PBXFileReference);
+    std::string pbxfileref = std::string(PBXFileReference);
     if(ext == "xib"){
-        pbxfileref = string(PBXFileReferenceXib);
+        pbxfileref = std::string(PBXFileReferenceXib);
     }
     
     
-    string UUID = generateUUID(srcFile);   // replace with theo's smarter system.
+    std::string UUID = generateUUID(srcFile);   // replace with theo's smarter system.
 
-    string name, path;
+    std::string name, path;
     splitFromLast(srcFile, "/", path, name);
 
     findandreplace( pbxfileref, "FILENAME", name);
@@ -809,7 +809,7 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
     if (addToBuild || addToBuildResource ){
 
         buildUUID = generateUUID(srcFile + "-build");
-        string pbxbuildfile = string(PBXBuildFile);
+	std::string pbxbuildfile = std::string(PBXBuildFile);
         findandreplace( pbxbuildfile, "FILEUUID", UUID);
         findandreplace( pbxbuildfile, "BUILDUUID", buildUUID);
         
@@ -838,8 +838,8 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
 
     if (addToResources == true && resourcesUUID != ""){
 		
-        string resUUID = generateUUID(srcFile + "-build");
-        string pbxbuildfile = string(PBXBuildFile);
+	std::string resUUID = generateUUID(srcFile + "-build");
+	std::string pbxbuildfile = std::string(PBXBuildFile);
         findandreplace( pbxbuildfile, "FILEUUID", UUID);
         findandreplace( pbxbuildfile, "BUILDUUID", resUUID);
         fileRefDoc.load_buffer(pbxbuildfile.c_str(), strlen(pbxbuildfile.c_str()));
@@ -861,11 +861,11 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
 
     if (bAddFolder == true){
 
-        vector < string > folders = ofSplitString(folder, "/", true);
+        std::vector < std::string > folders = ofSplitString(folder, "/", true);
 
         if (folders.size() > 1){
             if (folders[0] == "src"){
-                string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
 
                 folders.erase(folders.begin());
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
@@ -873,7 +873,7 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
 
             } else if (folders[0] == "addons"){
-                string xmlStr = "//key[contains(.,'"+addonUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+addonUUID+"')]/following-sibling::node()[1]";
 
                 folders.erase(folders.begin());
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
@@ -882,7 +882,7 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
 
             } else if (folders[0] == "local_addons"){
-                string xmlStr = "//key[contains(.,'"+localAddonUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+localAddonUUID+"')]/following-sibling::node()[1]";
 
                 folders.erase(folders.begin());
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
@@ -891,7 +891,7 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
 
             } else {
-                string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
 
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
 
@@ -905,7 +905,7 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
 
 
         pugi::xml_node array;
-		string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+        std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
         pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
         node.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
         //nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
@@ -918,7 +918,7 @@ void xcodeProject::addSrc(string srcFile, string folder, SrcType type){
 
 // todo: these three have very duplicate code... please fix up a bit.
 
-void xcodeProject::addInclude(string includeName){
+void xcodeProject::addInclude(std::string includeName){
 
 
 
@@ -946,7 +946,7 @@ void xcodeProject::addInclude(string includeName){
             pugi::xpath_node node = *it;
 
             //node.node().print(std::cout);
-            string headerXML = string(HeaderSearchPath);
+            std::string headerXML = std::string(HeaderSearchPath);
             pugi::xml_document headerDoc;
             pugi::xml_parse_result result = headerDoc.load_buffer(headerXML.c_str(), strlen(headerXML.c_str()));
 
@@ -989,7 +989,7 @@ void xcodeProject::addLibrary(const LibraryBinary & lib){
             pugi::xpath_node node = *it;
 
             //node.node().print(std::cout);
-            string ldXML = string(LDFlags);
+            std::string ldXML = std::string(LDFlags);
             pugi::xml_document ldDoc;
             pugi::xml_parse_result result = ldDoc.load_buffer(ldXML.c_str(), strlen(ldXML.c_str()));
 
@@ -1007,7 +1007,7 @@ void xcodeProject::addLibrary(const LibraryBinary & lib){
     //saveFile(projectDir + "/" + projectName + ".xcodeproj" + "/project.pbxproj");
 }
 
-void xcodeProject::addLDFLAG(string ldflag, LibType libType){
+void xcodeProject::addLDFLAG(std::string ldflag, LibType libType){
 
     char query[255];
     sprintf(query, "//key[contains(.,'baseConfigurationReference')]/parent::node()//key[contains(.,'OTHER_LDFLAGS')]/following-sibling::node()[1]");
@@ -1031,7 +1031,7 @@ void xcodeProject::addLDFLAG(string ldflag, LibType libType){
             pugi::xpath_node node = *it;
 
             //node.node().print(std::cout);
-            string ldXML = string(LDFlags);
+            std::string ldXML = std::string(LDFlags);
             pugi::xml_document ldDoc;
             pugi::xml_parse_result result = ldDoc.load_buffer(ldXML.c_str(), strlen(ldXML.c_str()));
 
@@ -1049,7 +1049,7 @@ void xcodeProject::addLDFLAG(string ldflag, LibType libType){
     //saveFile(projectDir + "/" + projectName + ".xcodeproj" + "/project.pbxproj");
 }
 
-void xcodeProject::addCFLAG(string cflag, LibType libType){
+void xcodeProject::addCFLAG(std::string cflag, LibType libType){
 
     char query[255];
     sprintf(query, "//key[contains(.,'baseConfigurationReference')]/parent::node()//key[contains(.,'OTHER_CFLAGS')]/following-sibling::node()[1]");
@@ -1073,7 +1073,7 @@ void xcodeProject::addCFLAG(string cflag, LibType libType){
             pugi::xpath_node node = *it;
 
             //node.node().print(std::cout);
-            string ldXML = string(CFlags);
+            std::string ldXML = std::string(CFlags);
             pugi::xml_document ldDoc;
             pugi::xml_parse_result result = ldDoc.load_buffer(ldXML.c_str(), strlen(ldXML.c_str()));
 
@@ -1091,7 +1091,7 @@ void xcodeProject::addCFLAG(string cflag, LibType libType){
     //saveFile(projectDir + "/" + projectName + ".xcodeproj" + "/project.pbxproj");
 }
 
-void xcodeProject::addAfterRule(string rule){
+void xcodeProject::addAfterRule(std::string rule){
     char query[255];
     sprintf(query, "//key[contains(.,'objects')]/following-sibling::node()[1]");
     pugi::xpath_node_set objects = doc.select_nodes(query);
@@ -1100,7 +1100,7 @@ void xcodeProject::addAfterRule(string rule){
     if (objects.size() > 0){
         for (auto node: objects){
             //node.node().print(std::cout);
-            string ldXML = string(afterRule);
+            std::string ldXML = std::string(afterRule);
             ofStringReplace(ldXML,"SHELL_SCRIPT",rule);
             pugi::xml_document ldDoc;
             pugi::xml_parse_result result = ldDoc.load_buffer(ldXML.c_str(), strlen(ldXML.c_str()));
@@ -1119,7 +1119,7 @@ void xcodeProject::addAfterRule(string rule){
     }
 }
 
-void xcodeProject::addCPPFLAG(string cppflag, LibType libType){
+void xcodeProject::addCPPFLAG(std::string cppflag, LibType libType){
 
     char query[255];
     sprintf(query, "//key[contains(.,'baseConfigurationReference')]/parent::node()//key[contains(.,'OTHER_CPLUSPLUSFLAGS')]/following-sibling::node()[1]");
@@ -1143,7 +1143,7 @@ void xcodeProject::addCPPFLAG(string cppflag, LibType libType){
             pugi::xpath_node node = *it;
 
             //node.node().print(std::cout);
-            string ldXML = string(CPPFlags);
+            std::string ldXML = std::string(CPPFlags);
             pugi::xml_document ldDoc;
             pugi::xml_parse_result result = ldDoc.load_buffer(ldXML.c_str(), strlen(ldXML.c_str()));
 
@@ -1208,7 +1208,7 @@ void xcodeProject::addAddon(ofAddon & addon){
             
             if (ofIsStringInString(addon.frameworks[i], "/System/Library")){
                 
-                vector < string > pathSplit = ofSplitString(addon.frameworks[i], "/");
+                std::vector < std::string > pathSplit = ofSplitString(addon.frameworks[i], "/");
                 
                 addFramework(pathSplit[pathSplit.size()-1],
                              addon.frameworks[i],
@@ -1216,7 +1216,7 @@ void xcodeProject::addAddon(ofAddon & addon){
                 
             } else {
             
-                vector < string > pathSplit = ofSplitString(addon.frameworks[i], "/");
+                std::vector < std::string > pathSplit = ofSplitString(addon.frameworks[i], "/");
                 
                 addFramework(pathSplit[pathSplit.size()-1],
                              addon.frameworks[i],

--- a/ofxProjectGenerator/src/projects/xcodeProject.h
+++ b/ofxProjectGenerator/src/projects/xcodeProject.h
@@ -29,7 +29,7 @@ public:
     void addAfterRule(std::string script);
     
     // specific to OSX
-    void addFramework(string name, string path, string folder="");  // folder if for non system frameworks
+    void addFramework(std::string name, std::string path, std::string folder="");  // folder if for non system frameworks
     
         
     

--- a/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/ofxProjectGenerator/src/utils/Utils.cpp
@@ -11,9 +11,6 @@
 #include <Poco/DirectoryIterator.h>
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/LocalDateTime.h>
-#include <iostream>
-#include <fstream>
-#include <string>
 #include <algorithm>
 #include <iostream>
 #include <fstream>
@@ -52,7 +49,7 @@ using namespace Poco;
 
 #include "ofUtils.h"
 
-string generateUUID(string input){
+std::string generateUUID(std::string input){
 
     std::string passphrase("openFrameworks"); // HMAC needs a passphrase
 
@@ -66,7 +63,7 @@ string generateUUID(string input){
     digestString = digestString.substr(0,24);
     digestString = ofToUpper(digestString);
 
-    string returnStr = digestString; // make a copy to return, fixes some odd visual studio behavior
+    std::string returnStr = digestString; // make a copy to return, fixes some odd visual studio behavior
     return returnStr;
 }
 
@@ -106,16 +103,16 @@ std::string LoadFileAsString(const std::string & fn)
     return oss.str();
 }
 
-void findandreplaceInTexfile (string fileName, std::string tFind, std::string tReplace ){
+void findandreplaceInTexfile (std::string fileName, std::string tFind, std::string tReplace ){
    if( ofFile::doesFileExist(fileName) ){
 	
 	    std::ifstream t(ofToDataPath(fileName).c_str());
 	    std::stringstream buffer;
 	    buffer << t.rdbuf();
-		string bufferStr = buffer.str();
+	    std::string bufferStr = buffer.str();
 		t.close();
 	    findandreplace(bufferStr, tFind, tReplace);
-		ofstream myfile;
+	    std::ofstream myfile;
         myfile.open (ofToDataPath(fileName).c_str());
         myfile << bufferStr;
 		myfile.close();
@@ -143,7 +140,7 @@ void findandreplaceInTexfile (string fileName, std::string tFind, std::string tR
 
 
 
-bool doesTagAndAttributeExist(pugi::xml_document & doc, string tag, string attribute, string newValue){
+bool doesTagAndAttributeExist(pugi::xml_document & doc, std::string tag, std::string attribute, std::string newValue){
     char xpathExpressionExists[1024];
     sprintf(xpathExpressionExists, "//%s[@%s='%s']", tag.c_str(), attribute.c_str(), newValue.c_str());
     //cout <<xpathExpressionExists <<endl;
@@ -155,14 +152,14 @@ bool doesTagAndAttributeExist(pugi::xml_document & doc, string tag, string attri
     }
 }
 
-pugi::xml_node appendValue(pugi::xml_document & doc, string tag, string attribute, string newValue, bool overwriteMultiple){
+pugi::xml_node appendValue(pugi::xml_document & doc, std::string tag, std::string attribute, std::string newValue, bool overwriteMultiple){
 
     if (overwriteMultiple == true){
         // find the existing node...
         char xpathExpression[1024];
         sprintf(xpathExpression, "//%s[@%s='%s']", tag.c_str(), attribute.c_str(), newValue.c_str());
         pugi::xpath_node node = doc.select_single_node(xpathExpression);
-        if(string(node.node().attribute(attribute.c_str()).value()).size() > 0){ // for some reason we get nulls here?
+        if(std::string(node.node().attribute(attribute.c_str()).value()).size() > 0){ // for some reason we get nulls here?
             // ...delete the existing node
             cout << "DELETING: " << node.node().name() << ": " << " " << node.node().attribute(attribute.c_str()).value() << endl;
             node.node().parent().remove_child(node.node());
@@ -186,7 +183,7 @@ pugi::xml_node appendValue(pugi::xml_document & doc, string tag, string attribut
 }
 
 // todo -- this doesn't use ofToDataPath -- so it's broken a bit.  can we fix?
-void getFilesRecursively(const string & path, vector < string > & fileNames){
+void getFilesRecursively(const std::string & path, std::vector < std::string > & fileNames){
 
     ofDirectory dir;
 
@@ -208,8 +205,8 @@ void getFilesRecursively(const string & path, vector < string > & fileNames){
 
 }
 
-static vector <string> platforms;
-bool isFolderNotCurrentPlatform(string folderName, string platform){
+static std::vector <std::string> platforms;
+bool isFolderNotCurrentPlatform(std::string folderName, std::string platform){
 	if( platforms.size() == 0 ){
 		platforms.push_back("osx");
         platforms.push_back("msys2");
@@ -230,20 +227,20 @@ bool isFolderNotCurrentPlatform(string folderName, string platform){
 	return false;
 }
 
-void splitFromLast(string toSplit, string deliminator, string & first, string & second){
+void splitFromLast(std::string toSplit, std::string deliminator, std::string & first, std::string & second){
     size_t found = toSplit.find_last_of(deliminator.c_str());
     first = toSplit.substr(0,found);
     second = toSplit.substr(found+1);
 }
 
-void splitFromFirst(string toSplit, string deliminator, string & first, string & second){
+void splitFromFirst(std::string toSplit, std::string deliminator, std::string & first, std::string & second){
     size_t found = toSplit.find(deliminator.c_str());
     first = toSplit.substr(0,found );
     second = toSplit.substr(found+deliminator.size());
 }
 
 
-void getFoldersRecursively(const string & path, vector < string > & folderNames, string platform){
+void getFoldersRecursively(const string & path, std::vector < std::string > & folderNames, std::string platform){
     ofDirectory dir;
     
     if (!ofIsStringInString(path, ".framework")){
@@ -259,7 +256,7 @@ void getFoldersRecursively(const string & path, vector < string > & folderNames,
 }
 
 
-void getFrameworksRecursively( const string & path, vector < string > & frameworks, string platform){
+void getFrameworksRecursively( const std::string & path, std::vector < std::string > & frameworks, std::string platform){
     
     
     ofDirectory dir;
@@ -273,8 +270,8 @@ void getFrameworksRecursively( const string & path, vector < string > & framewor
             //getLibsRecursively(dir.getPath(i), folderNames);
             
             // on osx, framework is a directory, let's not parse it....
-            string ext = "";
-            string first = "";
+	    std::string ext = "";
+	    std::string first = "";
             splitFromLast(dir.getPath(i), ".", first, ext);
             if (ext != "framework")
                 getFrameworksRecursively(dir.getPath(i), frameworks, platform);
@@ -287,7 +284,7 @@ void getFrameworksRecursively( const string & path, vector < string > & framewor
 
 
 
-void getDllsRecursively( const string & path, vector < string > & dlls, string platform){
+void getDllsRecursively( const std::string & path, std::vector < std::string > & dlls, std::string platform){
 	ofDirectory dir;
 	dir.listDir(path);
 
@@ -295,8 +292,8 @@ void getDllsRecursively( const string & path, vector < string > & dlls, string p
 		if (temp.isDirectory()){
 			getDllsRecursively(temp.path(), dlls, platform);
 		}else{
-			string ext = "";
-			string first = "";
+			std::string ext = "";
+			std::string first = "";
 			splitFromLast(temp.path(), ".", first, ext);
 			if (ext == "dll"){
 				dlls.push_back(temp.path());
@@ -308,7 +305,7 @@ void getDllsRecursively( const string & path, vector < string > & dlls, string p
 
 
 
-void getLibsRecursively(const string & path, vector < string > & libFiles, vector < LibraryBinary > & libLibs, string platform, string arch, string target){
+void getLibsRecursively(const std::string & path, std::vector < std::string > & libFiles, std::vector < LibraryBinary > & libLibs, std::string platform, std::string arch, std::string target){
     ofDirectory dir;
     dir.listDir(path);
 
@@ -316,7 +313,7 @@ void getLibsRecursively(const string & path, vector < string > & libFiles, vecto
         
     for (int i = 0; i < dir.size(); i++){
             
-        vector<string> splittedPath = ofSplitString(dir.getPath(i), std::filesystem::path("/").make_preferred().string());
+	std::vector<std::string> splittedPath = ofSplitString(dir.getPath(i), std::filesystem::path("/").make_preferred().string());
             
         ofFile temp(dir.getFile(i));
             
@@ -324,8 +321,8 @@ void getLibsRecursively(const string & path, vector < string > & libFiles, vecto
             //getLibsRecursively(dir.getPath(i), folderNames);
                 
             // on osx, framework is a directory, let's not parse it....
-            string ext = "";
-            string first = "";
+	    std::string ext = "";
+	    std::string first = "";
 			auto stem = std::filesystem::path(dir.getFile(i)).stem();
             splitFromLast(dir.getPath(i), ".", first, ext);
 			if (ext != "framework") {
@@ -354,9 +351,9 @@ void getLibsRecursively(const string & path, vector < string > & libFiles, vecto
                 }
             }              
                 
-            //string ext = ofFilePath::getFileExt(temp.getFile(i));
-            string ext;
-            string first;
+            //std::string ext = ofFilePath::getFileExt(temp.getFile(i));
+	    std::string ext;
+	    std::string first;
             splitFromLast(dir.getPath(i), ".", first, ext);
                 
 			if (ext == "a" || ext == "lib" || ext == "dylib" || ext == "so" || (ext == "dll" && platform != "vs")){
@@ -366,10 +363,10 @@ void getLibsRecursively(const string & path, vector < string > & libFiles, vecto
 					//TODO: THEO hack
 					if( platform == "ios" ){ //this is so we can add the osx libs for the simulator builds
 							
-						string currentPath = dir.getPath(i);
+						std::string currentPath = dir.getPath(i);
 							
 						//TODO: THEO double hack this is why we need install.xml - custom ignore ofxOpenCv 
-						if( currentPath.find("ofxOpenCv") == string::npos ){
+						if( currentPath.find("ofxOpenCv") == std::string::npos ){
 							ofStringReplace(currentPath, "ios", "osx");
 							if( ofFile::doesFileExist(currentPath) ){
 								libLibs.push_back({ currentPath,arch,target });
@@ -387,13 +384,13 @@ void getLibsRecursively(const string & path, vector < string > & libFiles, vecto
     
 }
 
-void fixSlashOrder(string & toFix){
+void fixSlashOrder(std::string & toFix){
     std::replace(toFix.begin(), toFix.end(),'/', '\\');
 }
 
 
-string unsplitString (vector < string > strings, string deliminator ){
-    string result;
+std::string unsplitString (std::vector < std::string > strings, std::string deliminator ){
+    std::string result;
     for (int i = 0; i < (int)strings.size(); i++){
         if (i != 0) result += deliminator;
         result += strings[i];
@@ -402,21 +399,21 @@ string unsplitString (vector < string > strings, string deliminator ){
 }
 
 
-static string OFRoot = "../../..";
+static std::string OFRoot = "../../..";
 
-string getOFRoot(){
+std::string getOFRoot(){
 	return ofFilePath::removeTrailingSlash(OFRoot);
 }
 
-string getAddonsRoot(){
+std::string getAddonsRoot(){
 	return ofFilePath::join(getOFRoot(), "addons");
 }
 
-void setOFRoot(string path){
+void setOFRoot(std::string path){
 	OFRoot = path;
 }
 
-string getOFRelPath(string from){
+std::string getOFRelPath(std::string from){
 	from = ofFilePath::removeTrailingSlash(from);
     Poco::Path base(true);
     base.parse(from);
@@ -426,7 +423,7 @@ string getOFRelPath(string from){
     path.makeAbsolute();
 
 
-	string relPath;
+	std::string relPath;
 	if (path.toString() == base.toString()){
 		// do something.
 	}
@@ -479,7 +476,7 @@ bool askOFRoot(){
 	return true;
 }
 
-string getOFRootFromConfig(){
+std::string getOFRootFromConfig(){
 	if(!checkConfigExists()) return "";
 	ofFile configFile(ofFilePath::join(ofFilePath::getUserHomeDir(),".ofprojectgenerator/config"),ofFile::ReadOnly);
 	ofBuffer filePath = configFile.readToBuffer();

--- a/ofxProjectGenerator/src/utils/Utils.h
+++ b/ofxProjectGenerator/src/utils/Utils.h
@@ -19,45 +19,45 @@
 #include "baseProject.h"
 
 
-string generateUUID(string input);
+std::string generateUUID(std::string input);
 
-string getOFRoot();
-string getAddonsRoot();
-void setOFRoot(string path);
+std::string getOFRoot();
+std::string getAddonsRoot();
+void setOFRoot(std::string path);
 void findandreplace( std::string& tInput, std::string tFind, std::string tReplace );
-void findandreplaceInTexfile (string fileName, string tFind, string tReplace );
+void findandreplaceInTexfile (std::string fileName, std::string tFind, std::string tReplace );
 
 
-bool doesTagAndAttributeExist(pugi::xml_document & doc, string tag, string attribute, string newValue);
-pugi::xml_node appendValue(pugi::xml_document & doc, string tag, string attribute, string newValue, bool addMultiple = false);
+bool doesTagAndAttributeExist(pugi::xml_document & doc, std::string tag, std::string attribute, std::string newValue);
+pugi::xml_node appendValue(pugi::xml_document & doc, std::string tag, std::string attribute, std::string newValue, bool addMultiple = false);
 
 
 
-void getFoldersRecursively(const string & path, vector < string > & folderNames, string platform);
-void getFilesRecursively(const string & path, vector < string > & fileNames);
-void getLibsRecursively(const string & path, vector < string > & libFiles, vector < LibraryBinary > & libLibs, string platform = "", string arch = "", string target = "");
-void getFrameworksRecursively( const string & path, vector < string > & frameworks,  string platform = "" );
-void getDllsRecursively( const string & path, vector < string > & dlls, string platform);
+void getFoldersRecursively(const std::string & path, std::vector < std::string > & folderNames, std::string platform);
+void getFilesRecursively(const std::string & path, std::vector < std::string > & fileNames);
+void getLibsRecursively(const std::string & path, std::vector < std::string > & libFiles, std::vector < LibraryBinary > & libLibs, std::string platform = "", std::string arch = "", std::string target = "");
+void getFrameworksRecursively( const std::string & path, std::vector < std::string > & frameworks,  std::string platform = "" );
+void getDllsRecursively( const std::string & path, std::vector < std::string > & dlls, std::string platform);
 
 
-void splitFromLast(string toSplit, string deliminator, string & first, string & second);
-void splitFromFirst(string toSplit, string deliminator, string & first, string & second);
+void splitFromLast(std::string toSplit, std::string deliminator, std::string & first, std::string & second);
+void splitFromFirst(std::string toSplit, std::string deliminator, std::string & first, std::string & second);
 
-void fixSlashOrder(string & toFix);
-string unsplitString (vector < string > strings, string deliminator );
+void fixSlashOrder(std::string & toFix);
+std::string unsplitString (std::vector < std::string > strings, std::string deliminator );
 
-string getOFRelPath(string from);
+std::string getOFRelPath(std::string from);
 
 bool checkConfigExists();
 bool askOFRoot();
-string getOFRootFromConfig();
+std::string getOFRootFromConfig();
 
 std::string getTargetString(ofTargetPlatform t);
 
 std::unique_ptr<baseProject> getTargetProject(ofTargetPlatform targ);
 
 template <class T>
-inline bool isInVector(T item, vector<T> & vec){
+inline bool isInVector(T item, std::vector<T> & vec){
     bool bIsInVector = false;
     for(int i=0;i<vec.size();i++){
         if(vec[i] == item){


### PR DESCRIPTION
Removing ```using namespace std``` from the core library (see [PR](https://github.com/openframeworks/openFrameworks/pull/5671)) broke the project generator. I fixed the errors caused by that, now it compiles.

Needs more testing. Also, there are a few more occurences of ```using namespace std``` in the project generator itself - i'm looking forward to remove them too if there is interest in that.