### PR TITLE
xcode prj defaults to error when method that's supposed to return doe…

### DIFF
--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -155,6 +155,8 @@ STRINGIFY(
           <array>
 		  <string>"-D__MACOSX_CORE__"</string>
 		  <string>"-mtune=native"</string>
+		  <string>"-Wreturn-type"</string>
+		  <string>"-Werror=return-type"</string>
           </array>
 
 );


### PR DESCRIPTION
…sn't (instead of warning)

As discussed in #163 - add compiler flags to Xcode projects created with project generator so that methods that miss a return value trigger compiler errors instead of warnings.