### PR TITLE
Feature/support xcode defines

### DIFF
--- a/ofxProjectGenerator/src/projects/xcodeProject.h
+++ b/ofxProjectGenerator/src/projects/xcodeProject.h
@@ -27,7 +27,7 @@ public:
     void addCFLAG(std::string cflag, LibType libType = RELEASE_LIB); // Other C Flags
     void addCPPFLAG(std::string cppflag, LibType libType = RELEASE_LIB); // Other C++ Flags
     void addAfterRule(std::string script);
-	void addDefine(std::string define, LibType libType = RELEASE_LIB); // Other C Flags
+	void addDefine(std::string define, LibType libType = RELEASE_LIB);
     
     // specific to OSX
     void addFramework(std::string name, std::string path, std::string folder="");  // folder if for non system frameworks

--- a/ofxProjectGenerator/src/projects/xcodeProject.h
+++ b/ofxProjectGenerator/src/projects/xcodeProject.h
@@ -27,6 +27,7 @@ public:
     void addCFLAG(std::string cflag, LibType libType = RELEASE_LIB); // Other C Flags
     void addCPPFLAG(std::string cppflag, LibType libType = RELEASE_LIB); // Other C++ Flags
     void addAfterRule(std::string script);
+	void addDefine(std::string define, LibType libType = RELEASE_LIB); // Other C Flags
     
     // specific to OSX
     void addFramework(std::string name, std::string path, std::string folder="");  // folder if for non system frameworks


### PR DESCRIPTION
This adds support for 
```
	ADDON_DEFINES = MY_DEFINE1 MY_DEFINE2
```

on Xcode projects.

Note that it doesn't handle

```
	ADDON_DEFINES = MY_DEFINE=VALUE
```
properly yet; I've looked into that but it would require a much more invasive change to handle that as the '=' token is expected only for defining variables.