### PR TITLE
increase max stdout buffer size to fix #122

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -573,7 +573,7 @@ ipc.on('update', function(event, arg) {
 
     var wholeString = pgApp + " " + recursiveString + " " + verboseString + " " + pathString + " " + platformString + " " + updatePath;
 
-    exec(wholeString, function callback(error, stdout, stderr) {
+    exec(wholeString, {maxBuffer : Infinity}, function callback(error, stdout, stderr) {
 
         if (error === null) {
             event.sender.send('consoleMessage', "<strong>" + wholeString + "</strong><br>" + stdout);
@@ -659,7 +659,7 @@ ipc.on('generate', function(event, arg) {
 
     var wholeString = pgApp + " " + verboseString + " " + pathString + " " + addonString + " " + platformString + " " + projectString;
 
-    exec(wholeString, function callback(error, stdout, stderr) {
+    exec(wholeString, {maxBuffer : Infinity}, function callback(error, stdout, stderr) {
 
         var wasError = false;
         var text = stdout; //Big text with many line breaks


### PR DESCRIPTION
Under certain circumstances, the output of the command line project generator could be too much for Node to accept and the process was killed.

As explained here https://nodejs.org/api/child_process.html#child_process_maxbuffer_and_unicode, the max size for the buffer size can be increased to resolve the issue.

This resolves https://github.com/openframeworks/projectGenerator/issues/122.