### PR TITLE
fix windows ENV on `build:vs`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "build:osx": "electron-packager . $npm_package_productName --icon=static/icon/of.icns --out=dist --ignore='dist' --ignore='readme.md' --prune --overwrite --version=0.30.0 --platform=darwin --arch=x64",
     "build:linux32": "electron-packager . $npm_package_productName --icon=static/icon/of.icns --out=dist --ignore='dist' --ignore='readme.md' --prune --overwrite --version=0.30.0 --platform=linux --arch=ia32",
     "build:linux64": "electron-packager . $npm_package_productName --icon=static/icon/of.icns --out=dist --ignore='dist' --ignore='readme.md' --prune --overwrite --version=0.30.0 --platform=linux --arch=x64",
-    "build:vs": "electron-packager . $npm_package_productName --icon=static/icon/of.icns --out=dist --ignore='dist' --ignore='readme.md' --prune --overwrite --version=0.30.0 --platform=win32 --arch=ia32"
+    "build:vs": "electron-packager . %npm_package_productName% --icon=static/icon/of.icns --out=dist --ignore='dist' --ignore='readme.md' --prune --overwrite --version=0.30.0 --platform=win32 --arch=ia32"
   },
   "files": [
     "index.html",


### PR DESCRIPTION
`npm run build:vs` on WPS (and cmd.exe), then create folder and exe have name `$npm_package_productName-win32-ia32`.

this PR fixed it.