### PR TITLE
Support ADDON_DATA in addon_config.mk

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -310,7 +310,7 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 	}
 
 	if(variable == "ADDON_DATA"){
-		addReplaceStringVector(data,value,addonRelPath,addToValue);
+		addReplaceStringVector(data,value,"",addToValue);
 	}
 
 	if(variable == "ADDON_LIBS_EXCLUDE"){

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -254,7 +254,23 @@ void baseProject::addAddon(std::string addonName){
         auto standardPath = ofFilePath::join(ofFilePath::join(getOFRoot(), "addons"), addonName);
         addon.fromFS(standardPath, target);
     }
+
     addAddon(addon);
+
+    // Process values from ADDON_DATA
+    if (addon.data.size()) {
+        string dest = ofFilePath::join(projectDir, "bin/data/");
+
+        for (auto& filename : addon.data) {
+            ofFile src(ofFilePath::join(addon.addonPath, filename));
+            if (!src.exists()) {
+                ofLogWarning() << "addon data file does not exist, skipping: " << filename;
+            } else {
+                ofLogVerbose() << "adding addon data files: " << filename;
+                src.copyTo(ofFilePath::join(dest, src.getFileName()), false, true);
+            }
+        }
+    }
 }
 
 void baseProject::addAddon(ofAddon & addon){

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -258,17 +258,37 @@ void baseProject::addAddon(std::string addonName){
     addAddon(addon);
 
     // Process values from ADDON_DATA
-    if (addon.data.size()) {
-        string dest = ofFilePath::join(projectDir, "bin/data/");
+    if(addon.data.size()){
 
-        for (auto& filename : addon.data) {
-            ofFile src(ofFilePath::join(addon.addonPath, filename));
-            if (!src.exists()) {
-                ofLogWarning() << "addon data file does not exist, skipping: " << filename;
-            } else {
-                ofLogVerbose() << "adding addon data files: " << filename;
-                src.copyTo(ofFilePath::join(dest, src.getFileName()), false, true);
-            }
+        for(auto& d : addon.data){
+
+			filesystem::path path(ofFilePath::join(addon.addonPath, d));
+			
+			if(filesystem::exists(path)){
+				if (filesystem::is_regular_file(path)){
+					ofFile src(path);
+					string dest = ofFilePath::join(projectDir, "bin/data/");
+					ofStringReplace(d, "data/", ""); // avoid to copy files at /data/data/*
+					bool success = src.copyTo(ofFilePath::join(dest, d), false, true);
+					if(success){
+						ofLogVerbose() << "adding addon data file: " << d;
+					}else {
+						ofLogWarning() << "Can not add addon data file: " << d;
+					}
+				}else if(filesystem::is_directory(path)){
+					ofDirectory dir(path);
+					string dest = ofFilePath::join(projectDir, "bin/data/");
+					ofStringReplace(d, "data/", ""); // avoid to copy files at /data/data/*
+					bool success = dir.copyTo(ofFilePath::join(dest, d), false, true);
+					if(success){
+						ofLogVerbose() << "adding addon data folder: " << d;
+					}else{
+						ofLogWarning() << "Can not add addon data folder: " << d;
+					}
+				}
+			}else{
+				ofLogWarning() << "addon data file does not exist, skipping: " << d;
+			}
         }
     }
 }

--- a/ofxProjectGenerator/src/projects/baseProject.h
+++ b/ofxProjectGenerator/src/projects/baseProject.h
@@ -66,7 +66,7 @@ public:
 	virtual void addDefine(std::string define, LibType libType = RELEASE_LIB) {}
 
     virtual void addAddon(std::string addon);
-	virtual void addAddon(ofAddon & addon);
+    virtual void addAddon(ofAddon & addon);
 
     std::string getName() { return projectName;}
     std::string getPath() { return projectDir; }


### PR DESCRIPTION
## original PR
https://github.com/openframeworks/projectGenerator/pull/92 by @mattfelsen in 2015-16.

## additional commit
I checked original PR still works nicely but only able to copy single file.
I added folder copy feature so that we can avoid listing up all files.
Tested on OSX and Windows, both of commandLine and frontend app works okay.

## Known problem
If we have same data folder/file in different addon, PG will copy both to /myProject/bin/data but overwrite. For example, considering we have following two addons. 
- ofxCoolShaders
  - /src
  - /data/img
- ofxCoolPhotos
  - /src
  - /data/img

And generate a project which copies both of /data/img. Then /myProject/bin/data/img folder will be overwritten by last addon specified. This might be solved by adding new "merge" feature to ofDirectory class in order to avoid overwrite folder but merge contents.
