### PR TITLE
Fix commentsinaddonsmake

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -480,7 +480,12 @@ ipc.on('isOFProjectFolder', function(event, project) {
                     }
                 });
 
-                //console.log(projectAddons);
+                // remove comments
+                projectAddons.forEach(function(element, index) {
+                    this[index] = this[index].split('#')[0];
+                  }, projectAddons);
+
+                // console.log('addons', projectAddons);
 
                 event.sender.send('selectAddons', projectAddons);
             } else {

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -323,7 +323,7 @@ void baseProject::parseAddons(){
 	    auto addon = ofTrim(line);
 	    if(addon[0] == '#') continue;
         if(addon == "") continue;
-        addAddon(addon);
+        addAddon(ofSplitString(addon, "#")[0]);
 	}
 }
 


### PR DESCRIPTION
Hello,
this close #180.

The project generator allows now comments at the middle of a line, e.g.: local_addons/ofxPackageManageableExampleAddon #https://github.com/thomasgeissl/ofxPackageManageableExampleAddon.git@a9244b298

This allows me to continue working on the ofPackageManager.

It would be very helpful if someone could double check and merge this pr. thanks.
Thomas
