### PR TITLE
strip ofTargetPlatform [experimental idea]

### DIFF
--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -56,7 +56,7 @@ std::string              directoryForRecursion;
 std::string              projectPath;
 std::string              ofPath;
 std::vector <std::string>     addons;
-std::vector <ofTargetPlatform>        targets;
+std::vector <std::string>     targets;
 std::string              ofPathEnv;
 std::string              currentWorkingDirectory;
 std::string              templateName;
@@ -87,7 +87,7 @@ bool printTemplates() {
     if(targets.size()>1){
 	std::vector<std::vector<baseProject::Template>> allPlatformsTemplates;
         for(auto & target: targets){
-            auto templates = getTargetProject(target)->listAvailableTemplates(getTargetString(target));
+            auto templates = getTargetProject(target)->listAvailableTemplates(target);
             allPlatformsTemplates.push_back(templates);
         }
 	std::set<baseProject::Template> commonTemplates;
@@ -122,8 +122,8 @@ bool printTemplates() {
     }else{
         bool templatesFound = false;
         for(auto & target: targets){
-            ofLogNotice() << "Templates for target " << getTargetString(target);
-            auto templates = getTargetProject(target)->listAvailableTemplates(getTargetString(target));
+            ofLogNotice() << "Templates for target " << target;
+            auto templates = getTargetProject(target)->listAvailableTemplates(target);
             for(auto & templateConfig: templates){
                 ofLogNotice() << templateConfig.name << "\t\t" << templateConfig.description;
             }
@@ -141,42 +141,42 @@ void addPlatforms(std::string value) {
 
     for (size_t i = 0; i < platforms.size(); i++) {
         if (platforms[i] == "linux") {
-            targets.push_back(OF_TARGET_LINUX);
+            targets.push_back("linux");
         }
         else if (platforms[i] == "linux64") {
-            targets.push_back(OF_TARGET_LINUX64);
+            targets.push_back("linux64");
         }
         else if (platforms[i] == "linuxarmv6l") {
-            targets.push_back(OF_TARGET_LINUXARMV6L);
+            targets.push_back("linuxarmv6l");
         }
         else if (platforms[i] == "linuxarmv7l") {
-            targets.push_back(OF_TARGET_LINUXARMV7L);
+            targets.push_back("linuxarmv7l");
         }
         else if (platforms[i] == "msys2") {
-            targets.push_back(OF_TARGET_MINGW);
+            targets.push_back("msys2");
         }
         else if (platforms[i] == "vs") {
-            targets.push_back(OF_TARGET_WINVS);
+            targets.push_back("vs");
         }
         else if (platforms[i] == "osx") {
-            targets.push_back(OF_TARGET_OSX);
+            targets.push_back("osx");
         }
         else if (platforms[i] == "ios") {
-            targets.push_back(OF_TARGET_IPHONE);
+            targets.push_back("ios");
         }
         else if (platforms[i] == "android") {
-            targets.push_back(OF_TARGET_ANDROID);
+            targets.push_back("android");
         }
         else if (platforms[i] == "allplatforms") {
-            targets.push_back(OF_TARGET_LINUX);
-            targets.push_back(OF_TARGET_LINUX64);
-            targets.push_back(OF_TARGET_LINUXARMV6L);
-            targets.push_back(OF_TARGET_LINUXARMV7L);
-            targets.push_back(OF_TARGET_MINGW);
-            targets.push_back(OF_TARGET_WINVS);
-            targets.push_back(OF_TARGET_OSX);
-            targets.push_back(OF_TARGET_IOS);
-            targets.push_back(OF_TARGET_ANDROID);
+            targets.push_back("linux");
+            targets.push_back("linux64");
+            targets.push_back("linuxarmv6l");
+            targets.push_back("linuxarmv7l");
+            targets.push_back("msys2");
+            targets.push_back("vs");
+            targets.push_back("osx");
+            targets.push_back("ios");
+            targets.push_back("android");
         }else{
             ofLogError() << "platform " << platforms[i] << " not valid";
         }
@@ -237,7 +237,7 @@ bool isGoodOFPath(std::string path) {
 
 
 
-void updateProject(std::string path, ofTargetPlatform target, bool bConsiderParameterAddons = true) {
+void updateProject(std::string path, std::string target, bool bConsiderParameterAddons = true) {
 
     // bConsiderParameterAddons = do we consider that the user could call update with a new set of addons
     // either we read the addons.make file, or we look at the parameter list.
@@ -262,7 +262,7 @@ void updateProject(std::string path, ofTargetPlatform target, bool bConsiderPara
 }
 
 
-void recursiveUpdate(std::string path, ofTargetPlatform target) {
+void recursiveUpdate(std::string path, std::string target) {
     
     ofDirectory dir(path);
     
@@ -347,7 +347,7 @@ int main(int argc, char* argv[]){
     bRecursive = false;
     bHelpRequested = false;
     bListTemplates = false;
-    targets.push_back(ofGetTargetPlatform());
+    targets.push_back( getTargetString(ofGetTargetPlatform()) );
     startTime = 0;
     nProjectsUpdated = 0;
     nProjectsCreated = 0;
@@ -537,7 +537,7 @@ int main(int argc, char* argv[]){
 
         for (int i = 0; i < (int)targets.size(); i++) {
             auto project = getTargetProject(targets[i]);
-            auto target = getTargetString(targets[i]);
+            auto target = targets[i];
 
             ofLogNotice() << "-----------------------------------------------";
             ofLogNotice() << "setting OF path to: " << ofPath;
@@ -588,7 +588,7 @@ int main(int argc, char* argv[]){
                     }else{
                         ofLogNotice() << "from -o option";
                     }
-                    ofLogNotice() << "target platform is: " << getTargetString(targets[i]);
+                    ofLogNotice() << "target platform is: " << targets[i];
 
                     if(templateName!=""){
                         ofLogNotice() << "using additional template " << templateName;
@@ -609,7 +609,7 @@ int main(int argc, char* argv[]){
             for (int i = 0; i < (int)targets.size(); i++) {
                 ofLogNotice() << "-----------------------------------------------";
                 ofLogNotice() << "updating an existing project";
-                ofLogNotice() << "target platform is: " << getTargetString(targets[i]);
+                ofLogNotice() << "target platform is: " << targets[i];
 
                 recursiveUpdate(projectPath, targets[i]);
                 

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -71,8 +71,18 @@ bool bHelpRequested;                    // did we request help?
 bool bListTemplates;                    // did we request help?
 bool bDryRun;                           // do dry run (useful for debugging recursive update)
 
-
-
+static const std::string PLATFORM_TEMPLATE_OSX{"osx"};
+static const std::string PLATFORM_TEMPLATE_IOS{"ios"};
+static const std::string PLATFORM_TEMPLATE_WINVS{"vs"};
+static const std::string PLATFORM_TEMPLATE_ANDROID{"android"};
+static const std::string PLATFORM_TEMPLATE_LINUX{"linux"};
+static const std::string PLATFORM_TEMPLATE_LINUX64{"linux64"};
+static const std::string PLATFORM_TEMPLATE_LINUXARMV6L{"linuxarmv6l"};
+static const std::string PLATFORM_TEMPLATE_LINUXARMV7L{"linuxarmv7l"};
+static const std::string PLATFORM_TEMPLATE_MINGW{"msys2"};
+static const std::string PLATFORM_TEMPLATE_VSCODE{"vscode"};
+static const std::string PLATFORM_TEMPLATE_EMACS{"emacs"};   // test
+static const std::string PLATFORM_TEMPLATE_VIM{"vim"};       // test
 
 //-------------------------------------------
 void consoleSpace() {
@@ -140,43 +150,46 @@ void addPlatforms(std::string value) {
     std::vector < std::string > platforms = ofSplitString(value, ",", true, true);
 
     for (size_t i = 0; i < platforms.size(); i++) {
-        if (platforms[i] == "linux") {
-            targets.push_back("linux");
+        if (platforms[i] == PLATFORM_TEMPLATE_LINUX) {
+            targets.push_back(PLATFORM_TEMPLATE_LINUX);
         }
-        else if (platforms[i] == "linux64") {
-            targets.push_back("linux64");
+        else if (platforms[i] == PLATFORM_TEMPLATE_LINUX64) {
+            targets.push_back(PLATFORM_TEMPLATE_LINUX64);
         }
-        else if (platforms[i] == "linuxarmv6l") {
-            targets.push_back("linuxarmv6l");
+        else if (platforms[i] == PLATFORM_TEMPLATE_LINUXARMV6L) {
+            targets.push_back(PLATFORM_TEMPLATE_LINUXARMV6L);
         }
-        else if (platforms[i] == "linuxarmv7l") {
-            targets.push_back("linuxarmv7l");
+        else if (platforms[i] == PLATFORM_TEMPLATE_LINUXARMV7L) {
+            targets.push_back(PLATFORM_TEMPLATE_LINUXARMV7L);
         }
-        else if (platforms[i] == "msys2") {
-            targets.push_back("msys2");
+        else if (platforms[i] == PLATFORM_TEMPLATE_MINGW) {
+            targets.push_back(PLATFORM_TEMPLATE_MINGW);
         }
-        else if (platforms[i] == "vs") {
-            targets.push_back("vs");
+        else if (platforms[i] == PLATFORM_TEMPLATE_WINVS) {
+            targets.push_back(PLATFORM_TEMPLATE_WINVS);
         }
-        else if (platforms[i] == "osx") {
-            targets.push_back("osx");
+        else if (platforms[i] == PLATFORM_TEMPLATE_OSX) {
+            targets.push_back(PLATFORM_TEMPLATE_OSX);
         }
-        else if (platforms[i] == "ios") {
-            targets.push_back("ios");
+        else if (platforms[i] == PLATFORM_TEMPLATE_IOS) {
+            targets.push_back(PLATFORM_TEMPLATE_IOS);
         }
-        else if (platforms[i] == "android") {
-            targets.push_back("android");
+        else if (platforms[i] == PLATFORM_TEMPLATE_ANDROID) {
+            targets.push_back(PLATFORM_TEMPLATE_ANDROID);
+        }
+        else if (platforms[i] == PLATFORM_TEMPLATE_VSCODE) {
+            targets.push_back(PLATFORM_TEMPLATE_VSCODE);
         }
         else if (platforms[i] == "allplatforms") {
-            targets.push_back("linux");
-            targets.push_back("linux64");
-            targets.push_back("linuxarmv6l");
-            targets.push_back("linuxarmv7l");
-            targets.push_back("msys2");
-            targets.push_back("vs");
-            targets.push_back("osx");
-            targets.push_back("ios");
-            targets.push_back("android");
+            targets.push_back(PLATFORM_TEMPLATE_LINUX);
+            targets.push_back(PLATFORM_TEMPLATE_LINUX64);
+            targets.push_back(PLATFORM_TEMPLATE_LINUXARMV6L);
+            targets.push_back(PLATFORM_TEMPLATE_LINUXARMV7L);
+            targets.push_back(PLATFORM_TEMPLATE_MINGW);
+            targets.push_back(PLATFORM_TEMPLATE_WINVS);
+            targets.push_back(PLATFORM_TEMPLATE_OSX);
+            targets.push_back(PLATFORM_TEMPLATE_IOS);
+            targets.push_back(PLATFORM_TEMPLATE_ANDROID);
         }else{
             ofLogError() << "platform " << platforms[i] << " not valid";
         }

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -30,6 +30,7 @@ constexpr option::Descriptor usage[] =
 #include "xcodeProject.h"
 #include "androidStudioProject.h"
 #include "Utils.h"
+#include "PlatformConstants.h"
 
 
 #define EXIT_OK 0
@@ -70,19 +71,6 @@ bool bRecursive;                        // do we recurse in update mode?
 bool bHelpRequested;                    // did we request help?
 bool bListTemplates;                    // did we request help?
 bool bDryRun;                           // do dry run (useful for debugging recursive update)
-
-static const std::string PLATFORM_TEMPLATE_OSX{"osx"};
-static const std::string PLATFORM_TEMPLATE_IOS{"ios"};
-static const std::string PLATFORM_TEMPLATE_WINVS{"vs"};
-static const std::string PLATFORM_TEMPLATE_ANDROID{"android"};
-static const std::string PLATFORM_TEMPLATE_LINUX{"linux"};
-static const std::string PLATFORM_TEMPLATE_LINUX64{"linux64"};
-static const std::string PLATFORM_TEMPLATE_LINUXARMV6L{"linuxarmv6l"};
-static const std::string PLATFORM_TEMPLATE_LINUXARMV7L{"linuxarmv7l"};
-static const std::string PLATFORM_TEMPLATE_MINGW{"msys2"};
-static const std::string PLATFORM_TEMPLATE_VSCODE{"vscode"};
-static const std::string PLATFORM_TEMPLATE_EMACS{"emacs"};   // test
-static const std::string PLATFORM_TEMPLATE_VIM{"vim"};       // test
 
 //-------------------------------------------
 void consoleSpace() {

--- a/ofxProjectGenerator/src/utils/PlatformConstants.h
+++ b/ofxProjectGenerator/src/utils/PlatformConstants.h
@@ -1,0 +1,14 @@
+#pragma once
+
+static const std::string PLATFORM_TEMPLATE_OSX{"osx"};
+static const std::string PLATFORM_TEMPLATE_IOS{"ios"};
+static const std::string PLATFORM_TEMPLATE_WINVS{"vs"};
+static const std::string PLATFORM_TEMPLATE_ANDROID{"android"};
+static const std::string PLATFORM_TEMPLATE_LINUX{"linux"};
+static const std::string PLATFORM_TEMPLATE_LINUX64{"linux64"};
+static const std::string PLATFORM_TEMPLATE_LINUXARMV6L{"linuxarmv6l"};
+static const std::string PLATFORM_TEMPLATE_LINUXARMV7L{"linuxarmv7l"};
+static const std::string PLATFORM_TEMPLATE_MINGW{"msys2"};
+static const std::string PLATFORM_TEMPLATE_VSCODE{"vscode"};
+static const std::string PLATFORM_TEMPLATE_EMACS{"emacs"};   // test
+static const std::string PLATFORM_TEMPLATE_VIM{"vim"};       // test

--- a/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/ofxProjectGenerator/src/utils/Utils.cpp
@@ -208,14 +208,14 @@ void getFilesRecursively(const std::string & path, std::vector < std::string > &
 static std::vector <std::string> platforms;
 bool isFolderNotCurrentPlatform(std::string folderName, std::string platform){
 	if( platforms.size() == 0 ){
-		platforms.push_back("osx");
-        platforms.push_back("msys2");
-		platforms.push_back("vs");
-		platforms.push_back("ios");
-		platforms.push_back("linux");
-		platforms.push_back("linux64");
-		platforms.push_back("android");
-		platforms.push_back("iphone");
+		platforms.push_back(PLATFORM_TEMPLATE_OSX);
+        platforms.push_back(PLATFORM_TEMPLATE_MINGW);
+		platforms.push_back(PLATFORM_TEMPLATE_WINVS);
+		platforms.push_back(PLATFORM_TEMPLATE_IOS);
+		platforms.push_back(PLATFORM_TEMPLATE_LINUX);
+		platforms.push_back(PLATFORM_TEMPLATE_LINUX64);
+		platforms.push_back(PLATFORM_TEMPLATE_ANDROID);
+		platforms.push_back("iphone");  // ??
 	}
 
 	for(int i = 0; i < platforms.size(); i++){
@@ -379,18 +379,18 @@ void getLibsRecursively(const std::string & path, std::vector < std::string > & 
 	    std::string first;
             splitFromLast(dir.getPath(i), ".", first, ext);
                 
-			if (ext == "a" || ext == "lib" || ext == "dylib" || ext == "so" || (ext == "dll" && platform != "vs")){
+			if (ext == "a" || ext == "lib" || ext == "dylib" || ext == "so" || (ext == "dll" && platform != PLATFORM_TEMPLATE_WINVS)){
                 if (platformFound){
 					libLibs.push_back({ dir.getPath(i), arch, target });
 						
 					//TODO: THEO hack
-					if( platform == "ios" ){ //this is so we can add the osx libs for the simulator builds
+					if( platform == PLATFORM_TEMPLATE_IOS ){ //this is so we can add the osx libs for the simulator builds
 							
 						std::string currentPath = dir.getPath(i);
 							
 						//TODO: THEO double hack this is why we need install.xml - custom ignore ofxOpenCv 
 						if( currentPath.find("ofxOpenCv") == std::string::npos ){
-							ofStringReplace(currentPath, "ios", "osx");
+							ofStringReplace(currentPath, PLATFORM_TEMPLATE_IOS, PLATFORM_TEMPLATE_OSX);
 							if( ofFile::doesFileExist(currentPath) ){
 								libLibs.push_back({ currentPath,arch,target });
 							}
@@ -509,23 +509,23 @@ std::string getOFRootFromConfig(){
 std::string getTargetString(ofTargetPlatform t){
     switch (t) {
     case OF_TARGET_OSX:
-        return "osx";
+        return PLATFORM_TEMPLATE_OSX;
     case OF_TARGET_MINGW:
-        return "msys2";
+        return PLATFORM_TEMPLATE_MINGW;
     case OF_TARGET_WINVS:
-        return "vs";
+        return PLATFORM_TEMPLATE_WINVS;
     case OF_TARGET_IOS:
-        return "ios";
+        return PLATFORM_TEMPLATE_IOS;
     case OF_TARGET_ANDROID:
-        return "android";
+        return PLATFORM_TEMPLATE_ANDROID;
     case OF_TARGET_LINUX:
-        return "linux";
+        return PLATFORM_TEMPLATE_LINUX;
     case OF_TARGET_LINUX64:
-        return "linux64";
+        return PLATFORM_TEMPLATE_LINUX64;
     case OF_TARGET_LINUXARMV6L:
-        return "linuxarmv6l";
+        return PLATFORM_TEMPLATE_LINUXARMV6L;
     case OF_TARGET_LINUXARMV7L:
-        return "linuxarmv7l";
+        return PLATFORM_TEMPLATE_LINUXARMV7L;
     default:
         return "";
     }
@@ -533,23 +533,23 @@ std::string getTargetString(ofTargetPlatform t){
 
 
 unique_ptr<baseProject> getTargetProject(std::string targ) {
-    if(targ == "osx") {
+    if(targ == PLATFORM_TEMPLATE_OSX) {
         return unique_ptr<xcodeProject>(new xcodeProject(targ));
-    }else if(targ=="msys2"){
+    }else if(targ==PLATFORM_TEMPLATE_MINGW){
         return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
-    }else if(targ == "vs"){
+    }else if(targ == PLATFORM_TEMPLATE_WINVS){
         return unique_ptr<visualStudioProject>(new visualStudioProject(targ));
-    }else if(targ == "ios"){
+    }else if(targ == PLATFORM_TEMPLATE_IOS){
         return unique_ptr<xcodeProject>(new xcodeProject(targ));
-    }else if(targ == "linux"){
+    }else if(targ == PLATFORM_TEMPLATE_LINUX){
         return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
-    }else if(targ == "linux64"){
+    }else if(targ == PLATFORM_TEMPLATE_LINUX64){
         return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
-    }else if(targ == "linuxarmv6l"){
+    }else if(targ == PLATFORM_TEMPLATE_LINUXARMV6L){
         return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
-    }else if(targ == "linuxarmv7l"){
+    }else if(targ == PLATFORM_TEMPLATE_LINUXARMV7L){
         return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
-    }else if(targ == "android"){
+    }else if(targ == PLATFORM_TEMPLATE_ANDROID){
         return unique_ptr<AndroidStudioProject>(new AndroidStudioProject(targ));
     }
     

--- a/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/ofxProjectGenerator/src/utils/Utils.cpp
@@ -532,27 +532,26 @@ std::string getTargetString(ofTargetPlatform t){
 }
 
 
-unique_ptr<baseProject> getTargetProject(ofTargetPlatform targ) {
-    switch (targ) {
-    case OF_TARGET_OSX:
-        return unique_ptr<xcodeProject>(new xcodeProject(getTargetString(targ)));
-    case OF_TARGET_MINGW:
-        return unique_ptr<QtCreatorProject>(new QtCreatorProject(getTargetString(targ)));
-    case OF_TARGET_WINVS:
-        return unique_ptr<visualStudioProject>(new visualStudioProject(getTargetString(targ)));
-    case OF_TARGET_IOS:
-        return unique_ptr<xcodeProject>(new xcodeProject(getTargetString(targ)));
-    case OF_TARGET_LINUX:
-        return unique_ptr<QtCreatorProject>(new QtCreatorProject(getTargetString(targ)));
-    case OF_TARGET_LINUX64:
-        return unique_ptr<QtCreatorProject>(new QtCreatorProject(getTargetString(targ)));
-    case OF_TARGET_LINUXARMV6L:
-        return unique_ptr<QtCreatorProject>(new QtCreatorProject(getTargetString(targ)));
-    case OF_TARGET_LINUXARMV7L:
-        return unique_ptr<QtCreatorProject>(new QtCreatorProject(getTargetString(targ)));
-    case OF_TARGET_ANDROID:
-        return unique_ptr<AndroidStudioProject>(new AndroidStudioProject(getTargetString(targ)));
-    default:
-        return unique_ptr<baseProject>();
+unique_ptr<baseProject> getTargetProject(std::string targ) {
+    if(targ == "osx") {
+        return unique_ptr<xcodeProject>(new xcodeProject(targ));
+    }else if(targ=="msys2"){
+        return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+    }else if(targ == "vs"){
+        return unique_ptr<visualStudioProject>(new visualStudioProject(targ));
+    }else if(targ == "ios"){
+        return unique_ptr<xcodeProject>(new xcodeProject(targ));
+    }else if(targ == "linux"){
+        return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+    }else if(targ == "linux64"){
+        return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+    }else if(targ == "linuxarmv6l"){
+        return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+    }else if(targ == "linuxarmv7l"){
+        return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+    }else if(targ == "android"){
+        return unique_ptr<AndroidStudioProject>(new AndroidStudioProject(targ));
     }
+    
+    return unique_ptr<baseProject>();
 }

--- a/ofxProjectGenerator/src/utils/Utils.h
+++ b/ofxProjectGenerator/src/utils/Utils.h
@@ -17,7 +17,7 @@
 #include "ofSystemUtils.h"
 #include "LibraryBinary.h"
 #include "baseProject.h"
-
+#include "PlatformConstants.h"
 
 std::string generateUUID(std::string input);
 

--- a/ofxProjectGenerator/src/utils/Utils.h
+++ b/ofxProjectGenerator/src/utils/Utils.h
@@ -55,7 +55,7 @@ std::string getOFRootFromConfig();
 
 std::string getTargetString(ofTargetPlatform t);
 
-std::unique_ptr<baseProject> getTargetProject(ofTargetPlatform targ);
+std::unique_ptr<baseProject> getTargetProject(std::string targ);
 
 template <class T>
 inline bool isInVector(T item, std::vector<T> & vec){


### PR DESCRIPTION
To be flexible to support another IDE, it might be better to remove ofTargetPlatform.
Because, for example, Qt, vscode, Atom, these IDE support multiple targets.

And for the name of the target like 'osx", ''vs', ''linuxarmv6l" etc, it would be nicer to use static const std::string, constexpr, or std::string_view etc instead of hardcoding with " ".

Related PR for vscode support -> https://github.com/openframeworks/projectGenerator/pull/202