### PR TITLE
Feature add template dropdown to frontend PG

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8,6 +8,7 @@ var fs = require('fs');
 
 
 var platforms;
+var templates;
 
 // var platforms = {
 //     "osx": "OS X (Xcode)",
@@ -204,7 +205,59 @@ ipc.on('setPlatforms', function(arg) {
 });
 
 
+ipc.on('setTemplates', function(arg) {
+    console.log("----------------");
+    console.log("got set templates");
+    console.log(arg);
 
+    templates = arg;
+
+    var select = document.getElementById("templateList");
+    var option, i;
+    for (var i in templates) {
+        console.log(i);
+        var myClass = 'template';
+
+        $('<div/>', {
+            "class": 'item',
+            "data-value": i
+        }).html(templates[i]).appendTo(select);
+    }
+
+    console.log(select);
+
+    // start the template drop down.
+    $('#templatesDropdown')
+    .dropdown({
+        allowAdditions: true,
+        fullTextSearch: 'exact',
+        match: "text"
+    });
+
+    // // set the platform to default
+    $('#templatesDropdown').dropdown('set exactly', defaultSettings['defaultTemplate']);
+
+    // Multi
+    var select = document.getElementById("templateListMulti");
+    var option, i;
+    for (var i in templates) {
+        var myClass = 'template';
+
+        $('<div/>', {
+            "class": 'item',
+            "data-value": i
+        }).html(templates[i]).appendTo(select);        
+    }
+
+    // start the platform drop down.
+    $('#templatesDropdownMulti')
+        .dropdown({
+            allowAdditions: false
+        });
+
+    // // set the platform to default
+    $('#templatesDropdownMulti').dropdown('set exactly', defaultSettings['defaultTemplate']);
+});
 
 
 
@@ -606,6 +659,7 @@ function setup() {
 
         // show default platform in GUI
         $("#defaultPlatform").html(defaultSettings['defaultPlatform']);
+        $("#defaultTemplate").html(defaultSettings['defaultTemplate']);
 
         // Enable tooltips
         //$("[data-toggle='tooltip']").tooltip();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -886,6 +886,12 @@ function generate() {
     // let's get all the info:
     var platformValueArray = getPlatformList();
 
+    var templatePicked = $("#templatesDropdown .active");
+    var templateValueArray = [];
+    for (var i = 0; i < templatePicked.length; i++){
+        templateValueArray.push($(templatePicked[i]).attr("data-value"));
+    }
+
     var addonsPicked = $("#addonsDropdown  .active");
     var addonValueArray = [];
 
@@ -905,6 +911,7 @@ function generate() {
     gen['projectName'] = $("#projectName").val();
     gen['projectPath'] = $("#projectPath").val();
     gen['platformList'] = platformValueArray;
+    gen['templateList'] = templateValueArray;
     gen['addonList'] = addonValueArray; //$("#addonsDropdown").val();
     gen['ofPath'] = $("#ofPath").val();
     gen['verbose'] = bVerbose;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -978,9 +978,17 @@ function enableAdvancedMode(isAdvanced) {
         $("body").addClass('advanced');
         $('a.updateMultiMenuOption').show();
 
+        $('#templatesSection').show();
+        $('#templatesSectionMulti').show();
+
     } else {
         $('#platformsDropdown').addClass("disabled");
         $('#platformsDropdown').dropdown('set exactly', defaultSettings['defaultPlatform']);
+
+        $('#templatesSection').hide();
+        $('#templatesSectionMulti').hide();
+        $('#templatesDropdown').dropdown('set exactly', '');
+        $('#templatesDropdownMulti').dropdown('set exactly', '');
 
         $("body").removeClass('advanced');
         $('a.updateMultiMenuOption').hide();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -262,6 +262,31 @@ ipc.on('setTemplates', function(arg) {
 });
 
 
+ipc.on('enableTemplate', function (arg) {
+
+    console.log('enableTemplate');
+
+    let items = $('#templatesDropdown .menu .item');
+
+    // enable all first
+    for (let i = 0; i < items.length; i++)
+    {
+        let item = $(items[i]);
+        item.removeClass("disabled");
+    }
+
+    for (let template of arg)
+    {
+        for (let i = 0; i < items.length; i++)
+        {
+            let item = $(items[i]);
+            if (item.attr('data-value') === template)
+            {
+                item.addClass("disabled");
+            }
+        }
+    }
+});
 
 //-------------------------------------------
 // select the list of addons and notify if some aren't installed
@@ -709,6 +734,18 @@ function setup() {
         $("#dropZoneUpdate").on('dragenter dragover drop', onDragUpdateFile).on('dragleave', function(e){
             $(this).removeClass("accept deny");
         });
+
+
+        // reflesh template dropdown list depends on selected platforms
+        $("#platformsDropdown").on('change', function () {
+            let selectedPlatforms = $("#platformsDropdown input").val();
+            let selectedPlatformArray = selectedPlatforms.trim().split(',');
+            let arg = {
+                ofPath: $("#ofPath").val(),
+                selectedPlatforms: selectedPlatformArray
+            }
+            ipc.send('refreshTemplateList', arg);
+        })
 
     });
 }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -269,19 +269,15 @@ ipc.on('enableTemplate', function (arg) {
     let items = $('#templatesDropdown .menu .item');
 
     // enable all first
-    for (let i = 0; i < items.length; i++)
-    {
+    for (let i = 0; i < items.length; i++) {
         let item = $(items[i]);
         item.removeClass("disabled");
     }
 
-    for (let template of arg)
-    {
-        for (let i = 0; i < items.length; i++)
-        {
+    for (let template of arg) {
+        for (let i = 0; i < items.length; i++) {
             let item = $(items[i]);
-            if (item.attr('data-value') === template)
-            {
+            if (item.attr('data-value') === template) {
                 item.addClass("disabled");
             }
         }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -229,13 +229,14 @@ ipc.on('setTemplates', function(arg) {
     // start the template drop down.
     $('#templatesDropdown')
     .dropdown({
-        allowAdditions: true,
+        allowAdditions: false,
         fullTextSearch: 'exact',
-        match: "text"
+        match: "text",
+        maxSelections: 1
     });
 
-    // // set the platform to default
-    $('#templatesDropdown').dropdown('set exactly', defaultSettings['defaultTemplate']);
+    // // set the template to default
+    //$('#templatesDropdown').dropdown('set exactly', defaultSettings['defaultTemplate']);
 
     // Multi
     var select = document.getElementById("templateListMulti");
@@ -252,11 +253,12 @@ ipc.on('setTemplates', function(arg) {
     // start the platform drop down.
     $('#templatesDropdownMulti')
         .dropdown({
-            allowAdditions: false
+            allowAdditions: false,
+            maxSelections: 1
         });
 
-    // // set the platform to default
-    $('#templatesDropdownMulti').dropdown('set exactly', defaultSettings['defaultTemplate']);
+    // // set the template to default
+    //$('#templatesDropdownMulti').dropdown('set exactly', defaultSettings['defaultTemplate']);
 });
 
 
@@ -659,7 +661,7 @@ function setup() {
 
         // show default platform in GUI
         $("#defaultPlatform").html(defaultSettings['defaultPlatform']);
-        $("#defaultTemplate").html(defaultSettings['defaultTemplate']);
+        //$("#defaultTemplate").html(defaultSettings['defaultTemplate']);
 
         // Enable tooltips
         //$("[data-toggle='tooltip']").tooltip();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -956,11 +956,16 @@ function updateRecursive() {
         platformValueArray.push($(platformsPicked[i]).attr("data-value"));
     }
 
-
+    var templatePicked = $("#templatesDropdownMulti .active");
+    var templateValueArray = [];
+    for (var i = 0; i < templatePicked.length; i++){
+        templateValueArray.push($(templatePicked[i]).attr("data-value"));
+    }
 
     var gen = {};
     gen['updatePath'] = $("#updateMultiplePath").val();
     gen['platformList'] = platformValueArray;
+    gen['templateList'] = templateValueArray;
     gen['updateRecursive'] = true;
     gen['ofPath'] = $("#ofPath").val();
     gen['verbose'] = bVerbose;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -265,8 +265,7 @@ ipc.on('setTemplates', function(arg) {
 ipc.on('enableTemplate', function (arg) {
 
     console.log('enableTemplate');
-
-    let items = $('#templatesDropdown .menu .item');
+    let items = arg.bMulti === false ? $('#templatesDropdown .menu .item') : $('#templatesDropdownMulti .menu .item');
 
     // enable all first
     for (let i = 0; i < items.length; i++) {
@@ -274,7 +273,7 @@ ipc.on('enableTemplate', function (arg) {
         item.removeClass("disabled");
     }
 
-    for (let template of arg) {
+    for (let template of arg.invalidTemplateList) {
         for (let i = 0; i < items.length; i++) {
             let item = $(items[i]);
             if (item.attr('data-value') === template) {
@@ -738,7 +737,18 @@ function setup() {
             let selectedPlatformArray = selectedPlatforms.trim().split(',');
             let arg = {
                 ofPath: $("#ofPath").val(),
-                selectedPlatforms: selectedPlatformArray
+                selectedPlatforms: selectedPlatformArray,
+                bMulti: false
+            }
+            ipc.send('refreshTemplateList', arg);
+        })
+        $("#platformsDropdownMulti").on('change', function () {
+            let selectedPlatforms = $("#platformsDropdownMulti input").val();
+            let selectedPlatformArray = selectedPlatforms.trim().split(',');
+            let arg = {
+                ofPath: $("#ofPath").val(),
+                selectedPlatforms: selectedPlatformArray,
+                bMulti: true
             }
             ipc.send('refreshTemplateList', arg);
         })

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -978,17 +978,17 @@ function enableAdvancedMode(isAdvanced) {
         $("body").addClass('advanced');
         $('a.updateMultiMenuOption').show();
 
-        $('#templatesSection').show();
-        $('#templatesSectionMulti').show();
+        $('#templateSection').show();
+        $('#templateSectionMulti').show();
 
     } else {
         $('#platformsDropdown').addClass("disabled");
         $('#platformsDropdown').dropdown('set exactly', defaultSettings['defaultPlatform']);
 
-        $('#templatesSection').hide();
-        $('#templatesSectionMulti').hide();
-        $('#templatesDropdown').dropdown('set exactly', '');
-        $('#templatesDropdownMulti').dropdown('set exactly', '');
+        $('#templateSection').hide();
+        $('#templateSectionMulti').hide();
+        $('#templateDropdown').dropdown('set exactly', '');
+        $('#templateDropdownMulti').dropdown('set exactly', '');
 
         $("body").removeClass('advanced');
         $('a.updateMultiMenuOption').hide();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -202,7 +202,7 @@ position: fixed;
 						</div>
 						<div id="test"></div>
 					</div>
-					<div id="templatesSection" class="field">
+					<div id="templateSection" class="field">
 						<label>Template:</label>
 						<div class="ui multiple search selection dropdown" id="templatesDropdown">
 							<input name="templates" type="hidden">
@@ -258,7 +258,7 @@ position: fixed;
 							</div>
 						</div>
 					</div>
-					<div id="templatesSectionMulti" class="field">
+					<div id="templateSectionMulti" class="field">
 						<label>Template:</label>
 						<div class="ui multiple search selection dropdown" id="templatesDropdownMulti">
 							<input name="templates" type="hidden">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -202,7 +202,7 @@ position: fixed;
 						</div>
 						<div id="test"></div>
 					</div>
-					<div class="field">
+					<div id="templatesSection" class="field">
 						<label>Template:</label>
 						<div class="ui multiple search selection dropdown" id="templatesDropdown">
 							<input name="templates" type="hidden">
@@ -258,7 +258,7 @@ position: fixed;
 							</div>
 						</div>
 					</div>
-					<div class="field">
+					<div id="templatesSectionMulti" class="field">
 						<label>Template:</label>
 						<div class="ui multiple search selection dropdown" id="templatesDropdownMulti">
 							<input name="templates" type="hidden">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -204,7 +204,7 @@ position: fixed;
 					</div>
 					<div class="field">
 						<label>Template:</label>
-						<div class="ui search selection dropdown" id="templatesDropdown">
+						<div class="ui multiple search selection dropdown" id="templatesDropdown">
 							<input name="templates" type="hidden">
 							<i class="dropdown icon"></i>
 							<div class="default text">Template...</div>
@@ -260,7 +260,7 @@ position: fixed;
 					</div>
 					<div class="field">
 						<label>Template:</label>
-						<div class="ui search selection dropdown" id="templatesDropdownMulti">
+						<div class="ui multiple search selection dropdown" id="templatesDropdownMulti">
 							<input name="templates" type="hidden">
 							<i class="dropdown icon"></i>
 							<div class="default text">Template...</div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -202,6 +202,18 @@ position: fixed;
 						</div>
 						<div id="test"></div>
 					</div>
+					<div class="field">
+						<label>Template:</label>
+						<div class="ui search selection dropdown" id="templatesDropdown">
+							<input name="templates" type="hidden">
+							<i class="dropdown icon"></i>
+							<div class="default text">Template...</div>
+							<div class="menu" id="templateList">
+							</div>
+						</div>
+						<div id="test"></div>
+					</div>
+
 					<div class="ui hidden divider"></div>
 					<div class="field">
 						<div class="ui olive button" id="generateButton" onclick="generate()">Generate</div>
@@ -245,6 +257,17 @@ position: fixed;
 							<div class="menu" id="platformListMulti">
 							</div>
 						</div>
+					</div>
+					<div class="field">
+						<label>Template:</label>
+						<div class="ui search selection dropdown" id="templatesDropdownMulti">
+							<input name="templates" type="hidden">
+							<i class="dropdown icon"></i>
+							<div class="default text">Template...</div>
+							<div class="menu" id="templateListMulti">
+							</div>
+						</div>
+						<div id="test"></div>
 					</div>
 					<div class="ui hidden divider"></div>
 					<div class="field">

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -625,7 +625,11 @@ ipc.on('refreshTemplateList', function (event, arg) {
         }
     }
 
-    mainWindow.webContents.send('enableTemplate', invalidTemplateList);
+    let returnArg = {
+        invalidTemplateList: invalidTemplateList,
+        bMulti: arg.bMulti
+    };
+    mainWindow.webContents.send('enableTemplate', returnArg);
 });
 
 ipc.on('getRandomSketchName', function(event, arg) {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -596,15 +596,20 @@ ipc.on('refreshTemplateList', function (event, arg) {
 
                     // platforms: array of platform suportd by this template
                     // selectedPlatforms: array of platform user selected on dropdown ui
-                    for (let platform of platforms)
+                    for (let selectedPlatform of selectedPlatforms)
                     {
-                        for (let selectedPlatform of selectedPlatforms)
+                        let bSupportedTemplate = false;
+                        for (let platform of platforms)
                         {
-                            if (selectedPlatform !== platform)
+                            if (selectedPlatform == platform)
                             {
-                                console.log("Selected platform " + selectedPlatform + " does not supports template " + template);
-                                invalidTemplateList.push(template);
+                                bSupportedTemplate = true;
                             }
+                        }
+                        if (bSupportedTemplate == false)
+                        {
+                            console.log("Selected platform " + selectedPlatform + " does not support template " + template);
+                            invalidTemplateList.push(template);
                         }
                     }
                 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -57,7 +57,6 @@ try {
         "defaultOfPath": "",
         "advancedMode": false,
         "defaultPlatform": myPlatform,
-        "defaultTemplate": "default",
         "showConsole": false,
         "showDeveloperTools": false,
         "defaultRelativeProjectPath": "apps/myApps",
@@ -100,7 +99,30 @@ var platforms = {
 };
 var bUseMoniker = obj["useDictionaryNameGenerator"];
 
-var templates = {};
+var templates = {
+    "emscripten": "Emscripten",
+    "gitignore": "Git Ignore",
+    "gles2": "Open GL ES 2",
+    "gl3.1": "Open GL 3.1",
+    "gl3.2": "Open GL 3.2",
+    "gl3.3": "Open GL 3.3",
+    "gl4.0": "Open GL 4.0",
+    "gl4.1": "Open GL 4.1",
+    "gl4.2": "Open GL 4.2",
+    "gl4.3": "Open GL 4.3",
+    "gl4.4": "Open GL 4.4",
+    "gl4.5": "Open GL 4.5",
+    "gles2": "Open GL ES 2",
+    "linux": "Linux",  // !!??
+    "msys2": "MSYS2/MinGW project template",
+    "nofmod": "OSX application with no FMOD linking",
+    "nowindow": "No window application",
+    "tvOS": "Apple tvOS template",
+    "unittest": "Unit test no window application",
+    "vscode": "Visual Studio Code",
+};
+
+
 
 if (!path.isAbsolute(defaultOfPath)) {
 
@@ -324,16 +346,27 @@ function parsePlatformsAndUpdateSelect(arg) {
     var platformsWeHave = {};
     var templatesWeHave = {};
 
-    templatesWeHave["default"] = "Default";
-    templatesWeHave["gl4.1"] = "GL4.1";
-
     if (folders === undefined || folders === null) {
         //do something
     } else {
-        for (var key in platforms) {
-            if (folders.indexOf(key) > -1) {
-                console.log("key " + key + " has value " + platforms[key]);
+        // check all folder name under /scripts/templates
+        for (var id in folders) {
+            var key = folders[id];
+            if (platforms[key]) {
+                // this folder is for platform
+                console.log("Found platform, key " + key + " has value " + platforms[key]);
                 platformsWeHave[key] = platforms[key];
+            }else{
+                // this folder is for template
+                if(templates[key]){
+                    console.log("Found template folder, key " + key + " has value " + templates[key]);
+                    templatesWeHave[key] = templates[key];
+                }else{
+                    // Unofficial folder name, maybe user's custom template? 
+                    // We use folder name for both of key and value
+                    console.log("Found unofficial folder, key " + key + " has value " + key);
+                    templatesWeHave[key] = key;
+                }
             }
         }
     }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -209,10 +209,10 @@ function toLetters(num) {
 app.on('ready', function() {
     // Create the browser window.
     mainWindow = new BrowserWindow({
-        width: 1920,
-        height: 1080,
-        resizable: true,
-        frame: true
+        width: 500,
+        height: 600,
+        resizable: false,
+        frame: false
     });
 
     // load jquery here:

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -57,6 +57,7 @@ try {
         "defaultOfPath": "",
         "advancedMode": false,
         "defaultPlatform": myPlatform,
+        "defaultTemplate": "default",
         "showConsole": false,
         "showDeveloperTools": false,
         "defaultRelativeProjectPath": "apps/myApps",
@@ -99,6 +100,7 @@ var platforms = {
 };
 var bUseMoniker = obj["useDictionaryNameGenerator"];
 
+var templates = {};
 
 if (!path.isAbsolute(defaultOfPath)) {
 
@@ -320,6 +322,11 @@ function parsePlatformsAndUpdateSelect(arg) {
     console.log(folders);
 
     var platformsWeHave = {};
+    var templatesWeHave = {};
+
+    templatesWeHave["default"] = "Default";
+    templatesWeHave["gl4.1"] = "GL4.1";
+
     if (folders === undefined || folders === null) {
         //do something
     } else {
@@ -336,6 +343,7 @@ function parsePlatformsAndUpdateSelect(arg) {
     // }
     mainWindow.webContents.send('setPlatforms', platformsWeHave);
 
+   mainWindow.webContents.send('setTemplates', templatesWeHave);
 
 }
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -649,6 +649,7 @@ ipc.on('update', function(event, arg) {
     var updatePath = "";
     var pathString = "";
     var platformString = "";
+    var templateString = "";
     var recursiveString = "";
     var verboseString = "";
 
@@ -659,6 +660,10 @@ ipc.on('update', function(event, arg) {
 
     if (update['platformList'] !== null) {
         platformString = "-p\"" + update['platformList'].join(",") + "\"";
+    }
+
+    if (update['templateList'] !== null) {
+        templateString = "-t\"" + update['templateList'].join(",") + "\"";
     }
 
     if (update['ofPath'] !== null) {
@@ -682,7 +687,7 @@ ipc.on('update', function(event, arg) {
         pgApp = "\"" + pgApp + "\"";
     }
 
-    var wholeString = pgApp + " " + recursiveString + " " + verboseString + " " + pathString + " " + platformString + " " + updatePath;
+    var wholeString = pgApp + " " + recursiveString + " " + verboseString + " " + pathString + " " + platformString + " " + templateString + " " + updatePath;
 
     exec(wholeString, {maxBuffer : Infinity}, function callback(error, stdout, stderr) {
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -742,7 +742,7 @@ ipc.on('generate', function(event, arg) {
     }
 
     if (generate['templateList'] !== null) {
-        platformString = "-t\"" + generate['templateList'].join(",") + "\"";
+        templateString = "-t\"" + generate['templateList'].join(",") + "\"";
     }
 
     if (generate['addonList'] !== null &&

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -601,12 +601,12 @@ ipc.on('refreshTemplateList', function (event, arg) {
                         let bSupportedTemplate = false;
                         for (let supportedPlatform of supportedPlatforms)
                         {
-                            if (selectedPlatform == supportedPlatform)
+                            if (selectedPlatform === supportedPlatform)
                             {
                                 bSupportedTemplate = true;
                             }
                         }
-                        if (bSupportedTemplate == false)
+                        if (bSupportedTemplate === false)
                         {
                             console.log("Selected platform " + selectedPlatform + " does not support template " + template);
                             invalidTemplateList.push(template);

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -723,12 +723,17 @@ ipc.on('generate', function(event, arg) {
     var pathString = "";
     var addonString = "";
     var platformString = "";
+    var templateString = "";
     var verboseString = "";
 
 
 
     if (generate['platformList'] !== null) {
         platformString = "-p\"" + generate['platformList'].join(",") + "\"";
+    }
+
+    if (generate['templateList'] !== null) {
+        platformString = "-t\"" + generate['templateList'].join(",") + "\"";
     }
 
     if (generate['addonList'] !== null &&
@@ -764,7 +769,7 @@ ipc.on('generate', function(event, arg) {
         pgApp = pgApp = "\"" + pgApp + "\"";
     }
 
-    var wholeString = pgApp + " " + verboseString + " " + pathString + " " + addonString + " " + platformString + " " + projectString;
+    var wholeString = pgApp + " " + verboseString + " " + pathString + " " + addonString + " " + platformString + " " + templateString + " " + projectString;
 
     exec(wholeString, {maxBuffer : Infinity}, function callback(error, stdout, stderr) {
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -575,39 +575,31 @@ ipc.on('refreshTemplateList', function (event, arg) {
     let invalidTemplateList = [];
 
     // iterate all avairable templates and check template.config file
-    for (let template in templates)
-    {
+    for (let template in templates) {
         let configFilePath = ofPath + "/scripts/templates/" + template + "/template.config";
-        if (fs.existsSync(configFilePath))
-        {
+        if (fs.existsSync(configFilePath)) {
             const lineByLine = require('n-readlines');
             const liner = new lineByLine(configFilePath);
             let line;
 
             // read line by line and try to find PLATFORMS setting
-            while (line = liner.next())
-            {
+            while (line = liner.next()) {
                 let line_st = line.toString();
-                if (line_st.includes('PLATFORMS'))
-                {
+                if (line_st.includes('PLATFORMS')) {
                     line_st = line_st.replace('PLATFORMS', '');
                     line_st = line_st.replace('=', '');
                     let supportedPlatforms = line_st.trim().split(' ');
 
                     // supportedPlatforms: array of platform supported by this template
                     // selectedPlatforms: array of platform selected by dropdown ui
-                    for (let selectedPlatform of selectedPlatforms)
-                    {
+                    for (let selectedPlatform of selectedPlatforms) {
                         let bSupportedTemplate = false;
-                        for (let supportedPlatform of supportedPlatforms)
-                        {
-                            if (selectedPlatform === supportedPlatform)
-                            {
+                        for (let supportedPlatform of supportedPlatforms) {
+                            if (selectedPlatform === supportedPlatform) {
                                 bSupportedTemplate = true;
                             }
                         }
-                        if (bSupportedTemplate === false)
-                        {
+                        if (bSupportedTemplate === false) {
                             console.log("Selected platform " + selectedPlatform + " does not support template " + template);
                             invalidTemplateList.push(template);
                         }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -592,16 +592,16 @@ ipc.on('refreshTemplateList', function (event, arg) {
                 {
                     line_st = line_st.replace('PLATFORMS', '');
                     line_st = line_st.replace('=', '');
-                    let platforms = line_st.trim().split(' ');
+                    let supportedPlatforms = line_st.trim().split(' ');
 
-                    // platforms: array of platform suportd by this template
-                    // selectedPlatforms: array of platform user selected on dropdown ui
+                    // supportedPlatforms: array of platform supported by this template
+                    // selectedPlatforms: array of platform selected by dropdown ui
                     for (let selectedPlatform of selectedPlatforms)
                     {
                         let bSupportedTemplate = false;
-                        for (let platform of platforms)
+                        for (let supportedPlatform of supportedPlatforms)
                         {
-                            if (selectedPlatform == platform)
+                            if (selectedPlatform == supportedPlatform)
                             {
                                 bSupportedTemplate = true;
                             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,8 +33,8 @@
   "dependencies": {
     "electron-debug": "^0.1.1",
     "moniker": "^0.1.2",
-    "walk": "^2.3.9"
-    "n-readlines": "^1.0.0",
+    "walk": "^2.3.9",
+    "n-readlines": "^1.0.0"
   },
   "devDependencies": {
     "electron-packager": "^5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "electron-debug": "^0.1.1",
     "moniker": "^0.1.2",
     "walk": "^2.3.9"
+    "n-readlines": "^1.0.0",
   },
   "devDependencies": {
     "electron-packager": "^5.0.0",


### PR DESCRIPTION
# Add template dropdown list to Electron frontend PG
![Screen Shot 2019-05-25 at 6 33 20 PM](https://user-images.githubusercontent.com/193280/58372364-48e09380-7f1c-11e9-91e3-7c43b396c3fc.png)


## List of official template
```
var templates = {
    "emscripten": "Emscripten",
    "gitignore": "Git Ignore",
    "gles2": "Open GL ES 2",
    "gl3.1": "Open GL 3.1",
    "gl3.2": "Open GL 3.2",
    "gl3.3": "Open GL 3.3",
    "gl4.0": "Open GL 4.0",
    "gl4.1": "Open GL 4.1",
    "gl4.2": "Open GL 4.2",
    "gl4.3": "Open GL 4.3",
    "gl4.4": "Open GL 4.4",
    "gl4.5": "Open GL 4.5",
    "gles2": "Open GL ES 2",
    "linux": "Linux",  // !!??
    "msys2": "MSYS2/MinGW project template",
    "nofmod": "OSX application with no FMOD linking",
    "nowindow": "No window application",
    "tvOS": "Apple tvOS template",
    "unittest": "Unit test no window application",
    "vscode": "Visual Studio Code",
};
```

## Limitations and issues
- Only allow a user to select a single template.
- Platform and template combination can be false. For example, Linux64 + tvOS
- Some of the templates overwrite src files and main.cpp, some not. This can be problematic when a user just wants to update a project.
- We might not need gl3.1 ~ gl4.5 templates since it only has a small difference each other.