### PR TITLE
Bugfix adds linking for ofxPoco libs. Fixes nigthlies not building.

### DIFF
--- a/commandLine/config.make
+++ b/commandLine/config.make
@@ -81,6 +81,9 @@ PROJECT_AFTER_OSX = cp "$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PROD
 # TODO: should this be a default setting?
 # PROJECT_LDFLAGS=-Wl,-rpath=./libs
 
+#Needs the Poco libs to link
+PROJECT_LDFLAGS += -L$(OF_ROOT)/addons/ofxPoco/libs/poco/lib/$(PLATFORM_LIB_SUBPATH)
+
 ################################################################################
 # PROJECT DEFINES
 #   Create a space-delimited list of DEFINES. The list will be converted into 


### PR DESCRIPTION
This should fix the nightlies not building.  
The poco lib locations weren't being set in the makefile for the command line PG and so create_package.sh was failing when trying to compile the PG. 

NOTE: There might be another way to add this linking path.
This is what worked for me :)  