### PR TITLE
Multiple flags are correctly read into VS projects, added support for preprocessor definitions in addons

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -140,7 +140,7 @@ bool ofAddon::checkCorrectVariable(string variable, ConfigParseState state){
 				variable == "ADDON_DATA" ||
 				variable == "ADDON_LIBS_EXCLUDE" || variable == "ADDON_SOURCES_EXCLUDE" || variable == "ADDON_INCLUDES_EXCLUDE" ||
 				variable == "ADDON_DLLS_TO_COPY" ||
-				variable == "ADDON_DEFINES");
+				variable == "ADDON_DEFINES" || variable == "ADDON_PREPROCESSOR_DEFINITIONS");
 	case Unknown:
 	default:
 		return false;
@@ -261,8 +261,13 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 		addReplaceStringVector(includePaths,value,addonRelPath,addToValue);
 	}
 
+	
 	if(variable == "ADDON_CFLAGS"){
 		addReplaceStringVector(cflags,value,"",addToValue);
+	}
+
+	if (variable == "ADDON_PREPROCESSOR_DEFINITIONS") {
+		addReplaceStringVector(preprocessorDefinitions, value, "", addToValue);
 	}
 
 	if(variable == "ADDON_CPPFLAGS"){
@@ -310,7 +315,7 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 	}
 
 	if(variable == "ADDON_DATA"){
-		addReplaceStringVector(data,value,"",addToValue);
+		addReplaceStringVector(data,value,addonRelPath,addToValue);
 	}
 
 	if(variable == "ADDON_LIBS_EXCLUDE"){

--- a/ofxProjectGenerator/src/addons/ofAddon.h
+++ b/ofxProjectGenerator/src/addons/ofAddon.h
@@ -45,6 +45,7 @@ public:
     std::vector < std::string > frameworks;		// osx only
     std::vector < std::string > data;
 	std::vector < std::string > defines;
+	std::vector < std::string > preprocessorDefinitions; // vs only
 
     // metadata
     std::string name;

--- a/ofxProjectGenerator/src/projects/visualStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.cpp
@@ -334,7 +334,7 @@ void visualStudioProject::addCFLAG(std::string cflag, LibType libType){
 		if(!additionalOptions){
 			items[i].node().child("ClCompile").append_child("AdditionalOptions").append_child(pugi::node_pcdata).set_value(cflag.c_str());
 		}else{
-			additionalOptions.set_value((std::string(additionalOptions.value()) + " " + cflag).c_str());
+			additionalOptions.first_child().set_value((std::string(additionalOptions.first_child().value()) + " " + cflag).c_str());
 		}
 	}
 
@@ -357,7 +357,7 @@ void visualStudioProject::addCPPFLAG(std::string cppflag, LibType libType){
 		if(!additionalOptions){
 			items[i].node().child("ClCompile").append_child("AdditionalOptions").append_child(pugi::node_pcdata).set_value(cppflag.c_str());
 		}else{
-			additionalOptions.set_value((std::string(additionalOptions.value()) + " " + cppflag).c_str());
+			additionalOptions.first_child().set_value((std::string(additionalOptions.first_child().value()) + " " + cppflag).c_str());
 		}
 	}
 
@@ -383,7 +383,7 @@ void visualStudioProject::addDefine(std::string define, LibType libType)
 			items[i].node().child("ClCompile").append_child("PreprocessorDefinitions").append_child(pugi::node_pcdata).set_value(define.c_str());
 		}
 		else {
-			additionalOptions.set_value((std::string(additionalOptions.value()) + " " + define).c_str());
+			additionalOptions.first_child().set_value((std::string(additionalOptions.first_child().value()) + " " + define).c_str());
 		}
 	}
 }
@@ -451,6 +451,8 @@ void visualStudioProject::addAddon(ofAddon & addon){
 		addCFLAG(addon.cflags[i],RELEASE_LIB);
 		addCFLAG(addon.cflags[i],DEBUG_LIB);
 	}
+
+
 	
 	for(int i=0;i<(int)addon.cppflags.size();i++){
 		ofLogVerbose() << "adding addon cppflags: " << addon.cppflags[i];
@@ -463,4 +465,5 @@ void visualStudioProject::addAddon(ofAddon & addon){
 		addDefine(addon.defines[i], RELEASE_LIB);
 		addDefine(addon.defines[i], DEBUG_LIB);
 	}
+
 }

--- a/ofxProjectGenerator/src/projects/visualStudioProject.h
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.h
@@ -22,6 +22,7 @@ public:
     void addCFLAG(std::string cflag, LibType libType = RELEASE_LIB); // C
     void addCPPFLAG(std::string cppflag, LibType libType = RELEASE_LIB); // C++
 	void addDefine(std::string define, LibType libType = RELEASE_LIB);
+	void addPreprocessorDefinitions(std::string define, LibType libType = RELEASE_LIB);
 
     void addAddon(ofAddon & addon);
 


### PR DESCRIPTION
Before the project generator only saved the last flag of each type and overwrote the previous ones. This could be fixed by overwriting the first child of the note but not the not itself

from
`additionalOptions.first_child().set_value`
to
`additionalOptions.set_value((std::string(additionalOptions.value()) + " " + cflag).c_str());`

Addionally I added the support for preprocessor definitions in addons in VS projects.