### PR TITLE
possible fix for linux pg errors. closes #209

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -652,6 +652,7 @@ ipc.on('update', function(event, arg) {
     var templateString = "";
     var recursiveString = "";
     var verboseString = "";
+    var rootPath = defaultOfPath;
 
     if (update['updatePath'] !== null) {
         updatePath = update['updatePath'];
@@ -668,6 +669,7 @@ ipc.on('update', function(event, arg) {
 
     if (update['ofPath'] !== null) {
         pathString = "-o\"" + update['ofPath'] + "\"";
+        rootPath = update['ofPath'];
     }
 
     if (update['updateRecursive'] === true) {
@@ -681,7 +683,7 @@ ipc.on('update', function(event, arg) {
     var pgApp = pathTemp.normalize(pathTemp.join(pathTemp.join(__dirname, "app"), "projectGenerator"));
     
     if( hostplatform == "linux" || hostplatform == "linux64" ){
-        pgApp = pathTemp.join(defaultOfPath, "apps/projectGenerator/commandLine/bin/projectGenerator");
+        pgApp = pathTemp.join(rootPath, "apps/projectGenerator/commandLine/bin/projectGenerator");
     }
 
     if( arg.platform == 'osx' || arg.platform == 'linux' || arg.platform == 'linux64' ){
@@ -737,7 +739,7 @@ ipc.on('generate', function(event, arg) {
     var platformString = "";
     var templateString = "";
     var verboseString = "";
-
+    var rootPath = defaultOfPath;
 
 
     if (generate['platformList'] !== null) {
@@ -757,6 +759,7 @@ ipc.on('generate', function(event, arg) {
 
     if (generate['ofPath'] !== null) {
         pathString = "-o\"" + generate['ofPath'] + "\"";
+        rootPath = generate['ofPath'];
     }
 
     if (generate['verbose'] === true) {
@@ -770,7 +773,7 @@ ipc.on('generate', function(event, arg) {
 
     var pgApp="";
     if(hostplatform == "linux" || hostplatform == "linux64"){
-        pgApp = pathTemp.join(defaultOfPath, "apps/projectGenerator/commandLine/bin/projectGenerator");
+        pgApp = pathTemp.join(rootPath, "apps/projectGenerator/commandLine/bin/projectGenerator");
         //pgApp = "projectGenerator";
     }else{
         pgApp = pathTemp.normalize(pathTemp.join(pathTemp.join(__dirname, "app"), "projectGenerator"));

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -680,7 +680,7 @@ ipc.on('update', function(event, arg) {
 
     var pgApp = pathTemp.normalize(pathTemp.join(pathTemp.join(__dirname, "app"), "projectGenerator"));
     
-    if( arg.platform == 'linux' || arg.platform == 'linux64' ){
+    if( hostplatform == "linux" || hostplatform == "linux64" ){
         pgApp = pathTemp.join(defaultOfPath, "apps/projectGenerator/commandLine/bin/projectGenerator");
     }
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -679,7 +679,10 @@ ipc.on('update', function(event, arg) {
     }
 
     var pgApp = pathTemp.normalize(pathTemp.join(pathTemp.join(__dirname, "app"), "projectGenerator"));
-
+    
+    if( arg.platform == 'linux' || arg.platform == 'linux64' ){
+        pgApp = pathTemp.join(defaultOfPath, "apps/projectGenerator/commandLine/bin/projectGenerator");
+    }
 
     if( arg.platform == 'osx' || arg.platform == 'linux' || arg.platform == 'linux64' ){
         pgApp = pgApp.replace(/ /g, '\\ ');
@@ -766,8 +769,9 @@ ipc.on('generate', function(event, arg) {
     }
 
     var pgApp="";
-    if(hostplatform == "linux"){
-        pgApp = "projectGenerator";
+    if(hostplatform == "linux" || hostplatform == "linux64"){
+        pgApp = pathTemp.join(defaultOfPath, "apps/projectGenerator/commandLine/bin/projectGenerator");
+        //pgApp = "projectGenerator";
     }else{
         pgApp = pathTemp.normalize(pathTemp.join(pathTemp.join(__dirname, "app"), "projectGenerator"));
     }


### PR DESCRIPTION
Not able to test this, but this PR _should_ set the pgApp path to `apps/projectGenerator/commandline/bin/projectGenerator` for linux. 

Meaning that as long as the commandline PG is compiled it should run from the frontend. 

The other approach ( which it looks like is partly in the existing code ) is to call the projectGenerator from /usr/local/bin. But that requires the user installs it there first after compiling.  

This _should_ work in both cases as the PG has to be compiled at `apps/projectGenerator/commandline/bin/projectGenerator` first and is only copied when installed. So should exist at this location either way. 

