### PR TITLE
feature  ADDON_FRAMEWORKS_EXCLUDE to exclude frameworks from OSX projects

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -138,7 +138,7 @@ bool ofAddon::checkCorrectVariable(string variable, ConfigParseState state){
 				variable == "ADDON_FRAMEWORKS" ||
 				variable == "ADDON_SOURCES" || variable == "ADDON_OBJC_SOURCES" || variable == "ADDON_CPP_SOURCES" || variable == "ADDON_HEADER_SOURCES" ||
 				variable == "ADDON_DATA" ||
-				variable == "ADDON_LIBS_EXCLUDE" || variable == "ADDON_SOURCES_EXCLUDE" || variable == "ADDON_INCLUDES_EXCLUDE" ||
+				variable == "ADDON_LIBS_EXCLUDE" || variable == "ADDON_SOURCES_EXCLUDE" || variable == "ADDON_INCLUDES_EXCLUDE" || variable == "ADDON_FRAMEWORKS_EXCLUDE" ||
 				variable == "ADDON_DLLS_TO_COPY" ||
 				variable == "ADDON_DEFINES");
 	case Unknown:
@@ -325,6 +325,10 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 		addReplaceStringVector(excludeIncludes,value,"",addToValue);
 	}
 
+	if (variable == "ADDON_FRAMEWORKS_EXCLUDE") {
+		addReplaceStringVector(excludeFrameworks, value, "", addToValue);
+	}
+
 	if (variable == "ADDON_DEFINES") {
 		addReplaceStringVector(defines, value, "", addToValue);
 	}
@@ -433,6 +437,7 @@ void ofAddon::parseConfig(){
 	exclude(objcsrcFiles,excludeSources);
 	exclude(headersrcFiles,excludeSources);
 	exclude(propsFiles, excludeSources);
+	exclude(frameworks, excludeFrameworks);
 	exclude(libs,excludeLibs);
 
 	ofLogVerbose("ofAddon") << "libs after exclusions " << libs.size();

--- a/ofxProjectGenerator/src/addons/ofAddon.h
+++ b/ofxProjectGenerator/src/addons/ofAddon.h
@@ -100,6 +100,7 @@ private:
     std::vector<std::string> excludeLibs;
     std::vector<std::string> excludeSources;
     std::vector<std::string> excludeIncludes;
+	std::vector<std::string> excludeFrameworks;
 };
 
 #endif /* OFADDON_H_ */


### PR DESCRIPTION
This is a very simple update to fix #230. 
tested with [ofxVVISF](https://github.com/danzeeeman/ofxVVISF)  