### PR TITLE
Fix multiple level dependencies, cache disk access to speed up generation.

### DIFF
--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -1,7 +1,8 @@
 #include "ofMain.h"
 #include "optionparser.h"
 #include "defines.h"
-enum  optionIndex { UNKNOWN, HELP, PLUS, RECURSIVE, LISTTEMPLATES, PLATFORMS, ADDONS, OFPATH, VERBOSE, TEMPLATE, DRYRUN, VERSION };
+enum  optionIndex { UNKNOWN, HELP, PLUS, RECURSIVE, LISTTEMPLATES, PLATFORMS, ADDONS, OFPATH, VERBOSE, TEMPLATE, DRYRUN, SRCEXTERNAL, VERSION};
+
 constexpr option::Descriptor usage[] =
 {
     {UNKNOWN, 0, "", "",option::Arg::None, "Options:\n" },
@@ -14,7 +15,8 @@ constexpr option::Descriptor usage[] =
     {VERBOSE, 0,"v","verbose",option::Arg::None, "  --verbose, -v  \trun verbose" },
     {TEMPLATE, 0,"t","template",option::Arg::Optional, "  --template, -t  \tproject template" },
     {DRYRUN, 0,"d","dryrun",option::Arg::None, "  --dryrun, -d  \tdry run, don't change files" },
-    {VERSION, 0, "w", "version", option::Arg::None, "  --version, -d  \treturn the current version"},
+    {SRCEXTERNAL, 0,"s","source",option::Arg::Optional, "  --source, -s  \trelative or absolute path to source or include folders external to the project (such as ../../../../common_utils/" },
+    {VERSION, 0, "w", "version", option::Arg::None, "  --version, -w  \treturn the current version"},
     {0,0,0,0,0,0}
 };
 
@@ -58,6 +60,7 @@ std::string              directoryForRecursion;
 std::string              projectPath;
 std::string              ofPath;
 std::vector <std::string>     addons;
+std::vector <std::string>     srcPaths;
 std::vector <ofTargetPlatform>        targets;
 std::string              ofPathEnv;
 std::string              currentWorkingDirectory;
@@ -263,6 +266,12 @@ void updateProject(std::string path, ofTargetPlatform target, bool bConsiderPara
         ofLogNotice() << "parsing addons.make";
         project->parseAddons();
     }
+    
+    if(!bDryRun){
+        for(auto & srcPath : srcPaths){
+            project->addSrcRecursively(srcPath);
+        }
+    }
 
     if (!bDryRun) project->save();
 }
@@ -415,7 +424,12 @@ int main(int argc, char* argv[]){
         }
     }
     
-    
+    if (options[SRCEXTERNAL].count() > 0){
+        if (options[SRCEXTERNAL].arg != NULL){
+            std::string srcString(options[SRCEXTERNAL].arg);
+            srcPaths = ofSplitString(srcString, ",", true, true);
+        }
+    }
     
     if (options[OFPATH].count() > 0){
         if (options[OFPATH].arg != NULL){
@@ -570,6 +584,9 @@ int main(int argc, char* argv[]){
             if (!bDryRun){
                 for(auto & addon: addons){
                     project->addAddon(addon);
+                }
+                for(auto & srcPath : srcPaths){
+                    project->addSrcRecursively(srcPath);
                 }
             }
             if (!bDryRun) project->save();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -28,7 +28,7 @@ var isFirstTimeSierra = false;
 var bVerbose = false;
 var localAddons = [];
 
-
+var numAddedSrcPaths = 1;
 
 //-----------------------------------------------------------------------------------
 // IPC
@@ -90,6 +90,12 @@ ipc.on('setProjectPath', function(arg) {
     //defaultSettings['lastUsedProjectPath'] = arg;
     //saveDefaultSettings();
     $("#projectName").trigger('change'); // checks if we need to be in update or generate mode
+});
+
+//-------------------------------------------
+ipc.on('setSourceExtraPath', function(arg, index) {
+    checkAddSourcePath(index);
+    $("#sourceExtra-"+index).val(arg);
 });
 
 //-------------------------------------------
@@ -914,12 +920,23 @@ function generate() {
         addonValueArray.push(localAddons[i]);
     }
 
+    // extra source locations
+    var srcExtraArr = "";
+    for(var i = 0; i < numAddedSrcPaths; i++){
+        var srcExtra = $("#sourceExtra-"+i).val();
+        if( srcExtra != '' ){
+            srcExtraArr += ", " + srcExtra;
+        }
+    }
+    
+
     var lengthOfPlatforms = platformValueArray.length;
 
     var gen = {};
 
     gen['projectName'] = $("#projectName").val();
     gen['projectPath'] = $("#projectPath").val();
+    gen['sourcePath'] = srcExtraArr;
     gen['platformList'] = platformValueArray;
     gen['templateList'] = templateValueArray;
     gen['addonList'] = addonValueArray; //$("#addonsDropdown").val();
@@ -997,12 +1014,16 @@ function switchGenerateMode(mode) {
         console.log('Switching GenerateMode to Update...');
 
         clearAddonSelection();
+        clearExtraSourceList();
 
     }
     // [default]: switch to createMode (generate new projects)
     else {
         // if previously in update mode, deselect Addons
-        if( $("#updateButton").is(":visible") ){ clearAddonSelection(); }
+        if( $("#updateButton").is(":visible") ){
+            clearAddonSelection();
+            clearExtraSourceList();
+        }
 
         $("#generateButton").show();
         $("#updateButton").hide();
@@ -1032,14 +1053,14 @@ function enableAdvancedMode(isAdvanced) {
         $('#platformsDropdown').removeClass("disabled");
         $("body").addClass('advanced');
         $('a.updateMultiMenuOption').show();
-
+        $('#sourceExtraSection').show();
         $('#templateSection').show();
         $('#templateSectionMulti').show();
 
     } else {
         $('#platformsDropdown').addClass("disabled");
         $('#platformsDropdown').dropdown('set exactly', defaultSettings['defaultPlatform']);
-
+        $('#sourceExtraSection').hide();
         $('#templateSection').hide();
         $('#templateSectionMulti').hide();
         $('#templateDropdown').dropdown('set exactly', '');
@@ -1114,13 +1135,43 @@ function browseOfPath() {
 }
 
 function browseProjectPath() {
-
     var path = $("#projectPath").val();
     if (path === ''){
         path = $("#ofPath").val();
     }
     ipc.send('pickProjectPath', path); // current path could go here
 }
+
+function clearExtraSourceList(){
+    $("#sourceExtraSection").empty();
+    $("#sourceExtraSection").append("<label>Additional source folders:</label>");
+    
+    checkAddSourcePath(-1);
+    numAddedSrcPaths = 1;
+}
+
+function checkAddSourcePath(index){
+    //if we don't have another field below us - add one
+    var nextFieldId = '#sourceExtra-'+(index+1);
+    if( $(nextFieldId).length == 0 ){
+        var nextIndex = index+1;
+        var extrafield = '<div class="field"> \
+           <div class="ui icon input fluid"> \
+               <input type="text" placeholder="Extra source path..." id="sourceExtra-'+nextIndex+'"> \
+               <i class="search link icon" onclick="browseSourcePath('+nextIndex+')"></i> \
+           </div> \
+        </div>';
+
+        $("#sourceExtraSection").append(extrafield);
+        numAddedSrcPaths++;
+    }
+}
+
+function browseSourcePath(index) {
+    var path = $("#ofPath").val();
+    ipc.send('pickSourcePath', path, index); // current path could go here
+}
+
 
 function browseImportProject() {
     var path = $("#projectPath").val();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -150,6 +150,15 @@ position: fixed;
 							<i class="search link icon" onclick="browseProjectPath()"></i>
 						</div>
 					</div>
+                    <div id="sourceExtraSection" class="field">
+                        <label>Additional source folders:</label>
+                        <div class="field">
+                            <div class="ui icon input fluid">
+                                <input type="text" placeholder="Extra source path..." id="sourceExtra-0">
+                                <i class="search link icon" onclick="browseSourcePath(0)"></i>
+                            </div>
+                        </div>
+                    </div>
 					<div class="field">
 						<label>
 							<a class="tooltip" href="http://www.ofxaddons.com/" data-toggle="external_target" data-content="Get more addons at ofxAddons.com" data-position="right center" id="ofx-addons-link">Addons</a>: &nbsp;

--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -446,7 +446,7 @@ void ofAddon::parseConfig(){
 	}
 }
 
-void ofAddon::fromFS(string path, string platform){
+bool ofAddon::fromFS(std::string path, const std::string & platform){
     clear();
     this->platform = platform;
 	string prefixPath;
@@ -464,6 +464,9 @@ void ofAddon::fromFS(string path, string platform){
         prefixPath = pathToOF;
     }
 
+	if(!ofDirectory::doesDirectoryExist(path)){
+		return false;
+	}
 
     string srcPath = ofFilePath::join(path, "/src");
     ofLogVerbose() << "in fromFS, trying src " << srcPath;
@@ -648,6 +651,7 @@ void ofAddon::fromFS(string path, string platform){
 
     parseConfig();
 
+	return true;
 }
 
 //void ofAddon::fromXML(string installXmlName){

--- a/ofxProjectGenerator/src/addons/ofAddon.h
+++ b/ofxProjectGenerator/src/addons/ofAddon.h
@@ -18,7 +18,7 @@ public:
 	
     ofAddon();
     
-	void fromFS(std::string path, std::string platform);
+	bool fromFS(std::string path, const std::string & platform);
 //	void fromXML(std::string installXmlName);
 	void clear();
 

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -260,30 +260,62 @@ bool baseProject::save(){
 	return saveProjectFile();
 }
 
+bool baseProject::isAddonCached(const std::string & addonPath, const std::string platform){
+	auto it = addonsCache.find(platform);
+	if (it == addonsCache.end()) return false;
+	auto it2 = it->second.find(addonPath);
+	return it2 != it->second.end();
+}
+
+
 void baseProject::addAddon(std::string addonName){
     ofAddon addon;
     addon.pathToOF = getOFRelPath(projectDir);
     addon.pathToProject = ofFilePath::getAbsolutePath(projectDir);
-    
 
-    
     auto localPath = ofFilePath::join(addon.pathToProject, addonName);
-    
+	bool addonOK = false;
+
+	bool inCache = isAddonCached(addonName, target);
+	//inCache = false; //uncomment to test no-cache scenario (disable cache alltogether)
+
     if (ofDirectory(addonName).exists()){
         // if it's an absolute path, convert to relative...
         string relativePath = ofFilePath::makeRelative(addon.pathToProject, addonName);
         addonName = relativePath;
         addon.isLocalAddon = true;
-        addon.fromFS(addonName, target);
+		if(!inCache){
+        		addonOK = addon.fromFS(addonName, target);
+		}else{
+			addon = addonsCache[target][addonName];
+			addonOK = true;
+		}
     } else if(ofDirectory(localPath).exists()){
         addon.isLocalAddon = true;
-        addon.fromFS(addonName, target);
+		if(!inCache){
+			addonOK = addon.fromFS(addonName, target);
+		}else{
+			addon = addonsCache[target][addonName];
+			addonOK = true;
+		}
     }else{
         addon.isLocalAddon = false;
         auto standardPath = ofFilePath::join(ofFilePath::join(getOFRoot(), "addons"), addonName);
-        addon.fromFS(standardPath, target);
+		if(!inCache){
+			addonOK = addon.fromFS(standardPath, target);
+		}else{
+			addon = addonsCache[target][addonName];
+			addonOK = true;
+		}
     }
+	if(!addonOK){
+		ofLogVerbose() << "Ignoring addon that doesn't seem to exist: " << addonName;
+		return; //if addon does not exist, stop early
+	}
 
+	if(!inCache){
+		addonsCache[target][addonName] = addon; //cache the addon so we dont have to be reading form disk all the time
+	}
     addAddon(addon);
 
     // Process values from ADDON_DATA
@@ -401,13 +433,23 @@ void baseProject::addSrcRecursively(std::string srcPath){
 }
 
 void baseProject::addAddon(ofAddon & addon){
+
     for(int i=0;i<(int)addons.size();i++){
-		if(addons[i].name==addon.name) return;
+		if(addons[i].name==addon.name){
+			return;
+		}
 	}
     
     for(int i=0;i<addon.dependencies.size();i++){
-        addAddon(addon.dependencies[i]);
+		for(int j=0;j<(int)addons.size();j++){
+			if(addon.dependencies[i] != addons[j].name){ //make sure dependencies of addons arent already added to prj
+				addAddon(addon.dependencies[i]);
+			}else{
+				ofLogVerbose() << "trying to add duplicated addon dependency! skipping: " << addon.dependencies[i];
+			}
+		}
     }
+
 
 	addons.push_back(addon);
 

--- a/ofxProjectGenerator/src/projects/baseProject.h
+++ b/ofxProjectGenerator/src/projects/baseProject.h
@@ -85,10 +85,15 @@ public:
     std::string target;
 
 protected:
+
     void recursiveCopyContents(const ofDirectory & srcDir, ofDirectory & destDir);
 
     std::vector<ofAddon> addons;
     std::vector<std::string> extSrcPaths;
+
+	//cached addons - if an addon is requested more than once, avoid loading from disk as it's quite slow
+	std::map<std::string,std::map<std::string, ofAddon>> addonsCache; //indexed by [platform][supplied path]
+	bool isAddonCached(const std::string & addonPath, const std::string platform); //is this addon in the mem cache?
 };
 
 

--- a/ofxProjectGenerator/src/projects/baseProject.h
+++ b/ofxProjectGenerator/src/projects/baseProject.h
@@ -67,6 +67,7 @@ public:
 
     virtual void addAddon(std::string addon);
     virtual void addAddon(ofAddon & addon);
+    virtual void addSrcRecursively(std::string srcPath);
 
     std::string getName() { return projectName;}
     std::string getPath() { return projectDir; }
@@ -87,6 +88,7 @@ protected:
     void recursiveCopyContents(const ofDirectory & srcDir, ofDirectory & destDir);
 
     std::vector<ofAddon> addons;
+    std::vector<std::string> extSrcPaths;
 };
 
 

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -1223,15 +1223,26 @@ void xcodeProject::addCPPFLAG(std::string cppflag, LibType libType){
 }
 
 void xcodeProject::addAddon(ofAddon & addon){
-	ofLogNotice() << "adding addon " << addon.name;
     for(int i=0;i<(int)addons.size();i++){
-		if(addons[i].name==addon.name) return;
+		if(addons[i].name==addon.name){
+			return;
+		}
 	}
 
     for(int i=0;i<addon.dependencies.size();i++){
         baseProject::addAddon(addon.dependencies[i]);
     }
 
+	for(int i=0;i<addon.dependencies.size();i++){
+		for(int j=0;j<(int)addons.size();j++){
+			if(addon.dependencies[i] != addons[j].name){ //make sure dependencies of addons arent already added to prj
+				baseProject::addAddon(addon.dependencies[i]);
+			}else{
+				//trying to add duplicated addon dependency... skipping!
+			}
+		}
+	}
+	ofLogNotice() << "adding addon: " << addon.name;
 	addons.push_back(addon);
 
     for(int i=0;i<(int)addon.includePaths.size();i++){
@@ -1293,9 +1304,5 @@ void xcodeProject::addAddon(ofAddon & addon){
                              addon.filesToFolders[addon.frameworks[i]]);
             }
         }
-                                                                                            
-                                                                                            //
-            
     }
-    
 }

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -218,6 +218,7 @@ STRINGIFY(
 xcodeProject::xcodeProject(std::string target)
 :baseProject(target){
     if( target == "osx" ){
+        projRootUUID    = "E4B69B4A0A3A1720003C02F2";
         srcUUID         = "E4B69E1C0A3A1BDC003C02F2";
         addonUUID       = "BB4B014C10F69532006C3DED";
         localAddonUUID  = "6948EE371B920CB800B5AC1A";
@@ -229,6 +230,7 @@ xcodeProject::xcodeProject(std::string target)
         frameworksBuildPhaseUUID = "E4328149138ABC9F0047C5CB";
         
     }else{
+        projRootUUID    = "29B97314FDCFA39411CA2CEA";
         srcUUID         = "E4D8936A11527B74007E1F53";
         addonUUID       = "BB16F26B0F2B646B00518274";
         localAddonUUID  = "6948EE371B920CB800B5AC1A";
@@ -875,8 +877,8 @@ void xcodeProject::addSrc(std::string srcFile, std::string folder, SrcType type)
 
         std::vector < std::string > folders = ofSplitString(folder, "/", true);
 
-        if (folders.size() > 1){
-            if (folders[0] == "src"){
+        if (folders.size()){
+            if (folders.size() > 1 && folders[0] == "src"){
                 std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
 
                 folders.erase(folders.begin());
@@ -884,7 +886,7 @@ void xcodeProject::addSrc(std::string srcFile, std::string folder, SrcType type)
                 pugi::xml_node nodeToAddTo = findOrMakeFolderSet( node, folders, "src");
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
 
-            } else if (folders[0] == "addons"){
+            } else if (folders.size() > 1 && folders[0] == "addons"){
                 std::string xmlStr = "//key[contains(.,'"+addonUUID+"')]/following-sibling::node()[1]";
 
                 folders.erase(folders.begin());
@@ -893,7 +895,7 @@ void xcodeProject::addSrc(std::string srcFile, std::string folder, SrcType type)
 
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
 
-            } else if (folders[0] == "local_addons"){
+            } else if (folders.size() > 1 && folders[0] == "local_addons"){
                 std::string xmlStr = "//key[contains(.,'"+localAddonUUID+"')]/following-sibling::node()[1]";
 
                 folders.erase(folders.begin());
@@ -903,13 +905,15 @@ void xcodeProject::addSrc(std::string srcFile, std::string folder, SrcType type)
                 nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
 
             } else {
-                std::string xmlStr = "//key[contains(.,'"+srcUUID+"')]/following-sibling::node()[1]";
+                std::string xmlStr = "//key[contains(.,'"+projRootUUID+"')]/following-sibling::node()[1]";
 
                 pugi::xml_node node = doc.select_single_node(xmlStr.c_str()).node();
+                pugi::xml_node nodeToAddTo = findOrMakeFolderSet( node, folders, folders[0]);
+                
+                nodeToAddTo.child("array").append_child("string").append_child(pugi::node_pcdata).set_value(UUID.c_str());
 
-                // I'm not sure the best way to proceed;
-                // we should maybe find the rootest level and add it there.
-                // TODO: fix this.
+                // This should add any files not in src/ addons/ or local_addons/
+                // to the root of the project hierarchy
             }
         };
 

--- a/ofxProjectGenerator/src/projects/xcodeProject.h
+++ b/ofxProjectGenerator/src/projects/xcodeProject.h
@@ -40,6 +40,7 @@ public:
     void saveScheme();
     void renameProject();
 
+    std::string projRootUUID;
     std::string srcUUID;
     std::string addonUUID;
     std::string localAddonUUID;

--- a/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/ofxProjectGenerator/src/utils/Utils.cpp
@@ -284,7 +284,7 @@ void getFrameworksRecursively( const std::string & path, std::vector < std::stri
 
 
 
-void getPropsRecursively(const std::string & path, std::vector < std::string > & props, std::string platform) {
+void getPropsRecursively(const std::string & path, std::vector < std::string > & props, const std::string & platform) {
 	ofDirectory dir;
 	dir.listDir(path);
 

--- a/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/ofxProjectGenerator/src/utils/Utils.cpp
@@ -290,6 +290,8 @@ void getPropsRecursively(const std::string & path, std::vector < std::string > &
 
 	for (auto & temp : dir) {
 		if (temp.isDirectory()) {
+            //skip example directories - this is needed as we are search all folders in the addons root path 
+            if( temp.getFileName().rfind("example", 0) == 0) continue;
 			getPropsRecursively(temp.path(), props, platform);
 		}
 		else {

--- a/ofxProjectGenerator/src/utils/Utils.h
+++ b/ofxProjectGenerator/src/utils/Utils.h
@@ -37,7 +37,7 @@ void getFoldersRecursively(const std::string & path, std::vector < std::string >
 void getFilesRecursively(const std::string & path, std::vector < std::string > & fileNames);
 void getLibsRecursively(const std::string & path, std::vector < std::string > & libFiles, std::vector < LibraryBinary > & libLibs, std::string platform = "", std::string arch = "", std::string target = "");
 void getFrameworksRecursively( const std::string & path, std::vector < std::string > & frameworks,  std::string platform = "" );
-void getPropsRecursively(const std::string & path, std::vector < std::string > & props, std::string platform);
+void getPropsRecursively(const std::string & path, std::vector < std::string > & props, const std::string & platform);
 void getDllsRecursively(const std::string & path, std::vector < std::string > & dlls, std::string platform);
 
 


### PR DESCRIPTION
This PR fixes an issue where the order in which addons are supplied can lead to different results, with addons sometimes not being included in the project. This only affects addons that are not stored in the `OpenFrameworks/addons` directory.

On projects where local addons are included, if those local addons have other local addons as a dependency, it could lead to a situation where some of those local addons end up not being added to the project. 

This big has been biting me for a very long time; I finally took the time to setup the CommandLine Xcode Project to be able to debug and find the issue. It turns out that PG keeps a list of addons that have been added to the project; if an addon has already been added, it will skip any other requests to add it. The problem comes when this first addon is added but it's empty. It shows up on the list as added, but nothing was really added, as the folder itself wasn't found. This can happen when PG parses dependcies of a local addon; I guess it expects all the dependencies to be "native" addons, but that's not always the case. Lots of local addons depend on other local addons, but PG currently just looks for depedency addons in the `OpenFrameworks/addons` folder. 

With the current implementation, if a folder does not exist with the addon name in `OpenFrameworks/addons`, PG still assumes its a valid addon, adds it to the project (which leads to nothing, as the addon has 0 files, 0 libs, etc) and puts it in the list of "added addons". This means if that later on it gets a request to add this same local addon but with the correct path (ie ../../externalAddons/ofxAnimatable), it would add the addon correctly, but bc ofxAnimatable is already on the list of added addons, its rejected and ignored... And the addon ends up not being part of the final created project.

The core of the fix is to not add addons to the projects if the folder is just not there. 

By making `fromFS()` return a bool we can indicate if it succeeded or failed to load an addon from disk. If it failed, then it was never an addon to begin with, so it should not take a spot on the "added addons" list.

Another feature of this addon is caching the result of `fromFS()` to RAM. This method is quite slow; for example ofxOpenCV takes several seconds. Currently, if multiple addons have it as a dependency, its scanned from disk every time its listed as a dependency, leading to 90+ seconds to create a project in some cases. With this PR, if an addon is loaded/indexed from disk once and its valid, it's cached to RAM so the next time it's requested it can skip the io access.

This leads to 3x faster generation on my test setup.

I tested this on windows and osx.

PS.

This PR doesn't fix the issue where local addons that have other local addons as a dependency will not get those dependencies added. Currently, "addon_config.mk" is parsed for dependencies, and for each addon listed there, it only looks inside the `OpenFrameworks/addons` folder for it. As local addons are often not there but in some other folder, they are not found this not added to the project. 

I usually keep addons that are not part of the OF release besides the OpenFrameworks folder, in a folder named "ExternalAddons". To create a project using those addons, I supply a relative path and it works great.

```
 ./projectGenerator -o"/Users/oriol/Desktop/OF_uricat/OpenFrameworks" -p"osx" -a"ofxOsc, ofxXmlSettings, ofxPoco,../../ExternalAddons/ofxAnimatable" ...
```


This is kind of hard to fix; as if ofxAnimatable has a dependency that's in "../../ExternalAddons", with the current API, PG has no way of knowing that... Unless it does some guesswork. We could look at all the paths that have been supplied for addons so far and dynamocally learn where to look for them; but I want to see what you think first. Another option is adding more CLI options to supply alternative addon locations (paths) in which to look for dependencies.

