### PR TITLE
Fix nested dependencies, cache addon reading from disk to speed up ge…

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -446,7 +446,7 @@ void ofAddon::parseConfig(){
 	}
 }
 
-void ofAddon::fromFS(string path, string platform){
+bool ofAddon::fromFS(std::string path, const std::string & platform){
     clear();
     this->platform = platform;
 	string prefixPath;
@@ -464,6 +464,9 @@ void ofAddon::fromFS(string path, string platform){
         prefixPath = pathToOF;
     }
 
+	if(!ofDirectory::doesDirectoryExist(path)){
+		return false;
+	}
 
     string srcPath = ofFilePath::join(path, "/src");
     ofLogVerbose() << "in fromFS, trying src " << srcPath;
@@ -648,6 +651,7 @@ void ofAddon::fromFS(string path, string platform){
 
     parseConfig();
 
+	return true;
 }
 
 //void ofAddon::fromXML(string installXmlName){

--- a/ofxProjectGenerator/src/addons/ofAddon.h
+++ b/ofxProjectGenerator/src/addons/ofAddon.h
@@ -18,7 +18,7 @@ public:
 	
     ofAddon();
     
-	void fromFS(std::string path, std::string platform);
+	bool fromFS(std::string path, const std::string & platform);
 //	void fromXML(std::string installXmlName);
 	void clear();
 

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -274,10 +274,10 @@ void baseProject::addAddon(std::string addonName){
     addon.pathToProject = ofFilePath::getAbsolutePath(projectDir);
 
     auto localPath = ofFilePath::join(addon.pathToProject, addonName);
-	bool addonOK = false;
+    bool addonOK = false;
 
-	bool inCache = isAddonInCache(addonName, target);
-	//inCache = false; //to test no-cache scenario
+    bool inCache = isAddonInCache(addonName, target);
+    //inCache = false; //to test no-cache scenario
 
     if (ofDirectory(addonName).exists()){
         // if it's an absolute path, convert to relative...
@@ -435,17 +435,17 @@ void baseProject::addSrcRecursively(std::string srcPath){
 void baseProject::addAddon(ofAddon & addon){
 
     for(int i=0;i<(int)addons.size();i++){
-		if(addons[i].name==addon.name){
-			return;
-		}
-	}
+        if(addons[i].name==addon.name){
+            return;
+        }
+    }
     
     for(int i=0;i<addon.dependencies.size();i++){
-		for(int j=0;j<(int)addons.size();j++){
-			if(addon.dependencies[i] != addons[j].name){ //make sure dependencies of addons arent already added to prj
-				addAddon(addon.dependencies[i]);
-			}else{
-				ofLogVerbose() << "trying to add duplicated addon dependency! skipping: " << addon.dependencies[i];
+        for(int j=0;j<(int)addons.size();j++){
+            if(addon.dependencies[i] != addons[j].name){ //make sure dependencies of addons arent already added to prj
+                addAddon(addon.dependencies[i]);
+            }else{
+                ofLogVerbose() << "trying to add duplicated addon dependency! skipping: " << addon.dependencies[i];
 			}
 		}
     }

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -260,30 +260,62 @@ bool baseProject::save(){
 	return saveProjectFile();
 }
 
+bool baseProject::isAddonInCache(const std::string & addonPath, const std::string platform){
+    auto it = addonsCache.find(platform);
+    if (it == addonsCache.end()) return false;
+    auto it2 = it->second.find(addonPath);
+    return it2 != it->second.end();
+}
+
+
 void baseProject::addAddon(std::string addonName){
     ofAddon addon;
     addon.pathToOF = getOFRelPath(projectDir);
     addon.pathToProject = ofFilePath::getAbsolutePath(projectDir);
-    
 
-    
     auto localPath = ofFilePath::join(addon.pathToProject, addonName);
-    
+	bool addonOK = false;
+
+	bool inCache = isAddonInCache(addonName, target);
+	//inCache = false; //to test no-cache scenario
+
     if (ofDirectory(addonName).exists()){
         // if it's an absolute path, convert to relative...
         string relativePath = ofFilePath::makeRelative(addon.pathToProject, addonName);
         addonName = relativePath;
         addon.isLocalAddon = true;
-        addon.fromFS(addonName, target);
+        if(!inCache){
+            addonOK = addon.fromFS(addonName, target);
+		}else{
+            addon = addonsCache[target][addonName];
+            addonOK = true;
+		}
     } else if(ofDirectory(localPath).exists()){
         addon.isLocalAddon = true;
-        addon.fromFS(addonName, target);
+        if(!inCache){
+            addonOK = addon.fromFS(addonName, target);
+        }else{
+            addon = addonsCache[target][addonName];
+            addonOK = true;
+		}
     }else{
         addon.isLocalAddon = false;
         auto standardPath = ofFilePath::join(ofFilePath::join(getOFRoot(), "addons"), addonName);
-        addon.fromFS(standardPath, target);
+        if(!inCache){
+            addonOK = addon.fromFS(standardPath, target);
+        }else{
+            addon = addonsCache[target][addonName];
+            addonOK = true;
+        }
+    }
+    if(!addonOK){
+        ofLogVerbose() << "Ignoring addon that doesn't seem to exist: " << addonName;
+        return; //if addon does not exist, stop early
     }
 
+    if(!inCache){
+        addonsCache[target][addonName] = addon; //cache the addon so we dont have to be reading form disk all the time
+    }
     addAddon(addon);
 
     // Process values from ADDON_DATA
@@ -401,13 +433,23 @@ void baseProject::addSrcRecursively(std::string srcPath){
 }
 
 void baseProject::addAddon(ofAddon & addon){
+
     for(int i=0;i<(int)addons.size();i++){
-		if(addons[i].name==addon.name) return;
+		if(addons[i].name==addon.name){
+			return;
+		}
 	}
     
     for(int i=0;i<addon.dependencies.size();i++){
-        addAddon(addon.dependencies[i]);
+		for(int j=0;j<(int)addons.size();j++){
+			if(addon.dependencies[i] != addons[j].name){ //make sure dependencies of addons arent already added to prj
+				addAddon(addon.dependencies[i]);
+			}else{
+				ofLogVerbose() << "trying to add duplicated addon dependency! skipping: " << addon.dependencies[i];
+			}
+		}
     }
+
 
 	addons.push_back(addon);
 

--- a/ofxProjectGenerator/src/projects/baseProject.h
+++ b/ofxProjectGenerator/src/projects/baseProject.h
@@ -87,12 +87,12 @@ public:
 protected:
     void recursiveCopyContents(const ofDirectory & srcDir, ofDirectory & destDir);
 
-	std::vector<ofAddon> addons;
-	std::vector<std::string> extSrcPaths;
+    std::vector<ofAddon> addons;
+    std::vector<std::string> extSrcPaths;
 
-	//cached addons - if an addon is requested more than once, avoid loading from disk as it's quite slow
-	std::map<std::string,std::map<std::string, ofAddon>> addonsCache; //indexed by [platform][supplied path]
-	bool isAddonInCache(const std::string & addonPath, const std::string platform); //is this addon in the mem cache?
+    //cached addons - if an addon is requested more than once, avoid loading from disk as it's quite slow
+    std::map<std::string,std::map<std::string, ofAddon>> addonsCache; //indexed by [platform][supplied path]
+    bool isAddonInCache(const std::string & addonPath, const std::string platform); //is this addon in the mem cache?
 };
 
 

--- a/ofxProjectGenerator/src/projects/baseProject.h
+++ b/ofxProjectGenerator/src/projects/baseProject.h
@@ -87,8 +87,12 @@ public:
 protected:
     void recursiveCopyContents(const ofDirectory & srcDir, ofDirectory & destDir);
 
-    std::vector<ofAddon> addons;
-    std::vector<std::string> extSrcPaths;
+	std::vector<ofAddon> addons;
+	std::vector<std::string> extSrcPaths;
+
+	//cached addons - if an addon is requested more than once, avoid loading from disk as it's quite slow
+	std::map<std::string,std::map<std::string, ofAddon>> addonsCache; //indexed by [platform][supplied path]
+	bool isAddonInCache(const std::string & addonPath, const std::string platform); //is this addon in the mem cache?
 };
 
 

--- a/ofxProjectGenerator/src/projects/visualStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.cpp
@@ -397,6 +397,7 @@ void visualStudioProject::addAddon(ofAddon & addon){
         baseProject::addAddon(addon.dependencies[i]);
     }
 
+	ofLogNotice() << "adding addon: " << addon.name;
 	addons.push_back(addon);
 
     for(int i=0;i<(int)addon.includePaths.size();i++){

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -1224,8 +1224,8 @@ void xcodeProject::addCPPFLAG(std::string cppflag, LibType libType){
 
 void xcodeProject::addAddon(ofAddon & addon){
     for(int i=0;i<(int)addons.size();i++){
-		if(addons[i].name==addon.name){
-			return;
+        if(addons[i].name==addon.name){
+            return;
 		}
 	}
 
@@ -1242,8 +1242,8 @@ void xcodeProject::addAddon(ofAddon & addon){
 			}
 		}
 	}
-	ofLogNotice() << "adding addon: " << addon.name;
-	addons.push_back(addon);
+    ofLogNotice() << "adding addon: " << addon.name;
+    addons.push_back(addon);
 
     for(int i=0;i<(int)addon.includePaths.size();i++){
         ofLogVerbose() << "adding addon include path: " << addon.includePaths[i];

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -1223,15 +1223,26 @@ void xcodeProject::addCPPFLAG(std::string cppflag, LibType libType){
 }
 
 void xcodeProject::addAddon(ofAddon & addon){
-	ofLogNotice() << "adding addon " << addon.name;
     for(int i=0;i<(int)addons.size();i++){
-		if(addons[i].name==addon.name) return;
+		if(addons[i].name==addon.name){
+			return;
+		}
 	}
 
     for(int i=0;i<addon.dependencies.size();i++){
         baseProject::addAddon(addon.dependencies[i]);
     }
 
+	for(int i=0;i<addon.dependencies.size();i++){
+		for(int j=0;j<(int)addons.size();j++){
+			if(addon.dependencies[i] != addons[j].name){ //make sure dependencies of addons arent already added to prj
+				baseProject::addAddon(addon.dependencies[i]);
+			}else{
+				//trying to add duplicated addon dependency... skipping!
+			}
+		}
+	}
+	ofLogNotice() << "adding addon: " << addon.name;
 	addons.push_back(addon);
 
     for(int i=0;i<(int)addon.includePaths.size();i++){
@@ -1293,9 +1304,5 @@ void xcodeProject::addAddon(ofAddon & addon){
                              addon.filesToFolders[addon.frameworks[i]]);
             }
         }
-                                                                                            
-                                                                                            //
-            
     }
-    
 }

--- a/ofxProjectGenerator/src/utils/Utils.cpp
+++ b/ofxProjectGenerator/src/utils/Utils.cpp
@@ -284,9 +284,11 @@ void getFrameworksRecursively( const std::string & path, std::vector < std::stri
 
 
 
-void getPropsRecursively(const std::string & path, std::vector < std::string > & props, std::string platform) {
-	ofDirectory dir;
-	dir.listDir(path);
+void getPropsRecursively(const std::string & path, std::vector < std::string > & props, const std::string & platform) {
+
+    if(!ofDirectory::doesDirectoryExist(path)) return; //check for dir existing before listing to prevent lots of "source directory does not exist" errors printed on console
+    ofDirectory dir;
+    dir.listDir(path);
 
 	for (auto & temp : dir) {
 		if (temp.isDirectory()) {

--- a/ofxProjectGenerator/src/utils/Utils.h
+++ b/ofxProjectGenerator/src/utils/Utils.h
@@ -37,7 +37,7 @@ void getFoldersRecursively(const std::string & path, std::vector < std::string >
 void getFilesRecursively(const std::string & path, std::vector < std::string > & fileNames);
 void getLibsRecursively(const std::string & path, std::vector < std::string > & libFiles, std::vector < LibraryBinary > & libLibs, std::string platform = "", std::string arch = "", std::string target = "");
 void getFrameworksRecursively( const std::string & path, std::vector < std::string > & frameworks,  std::string platform = "" );
-void getPropsRecursively(const std::string & path, std::vector < std::string > & props, std::string platform);
+void getPropsRecursively(const std::string & path, std::vector < std::string > & props, const std::string & platform);
 void getDllsRecursively(const std::string & path, std::vector < std::string > & dlls, std::string platform);
 
 


### PR DESCRIPTION
This is a re-submission of this PR https://github.com/openframeworks/projectGenerator/pull/251

--

This PR fixes an issue where the order in which addons are supplied can lead to different results, with addons sometimes not being included in the project. This only affects addons that are not stored in the `OpenFrameworks/addons` directory.

On projects where local addons are included, if those local addons have other local addons as a dependency, it could lead to a situation where some of those local addons end up not being added to the project. 

This bug has been biting me for a very long time; I finally took the time to setup the CommandLine Xcode Project to be able to debug and find the issue. It turns out that PG keeps a list of addons that have been added to the project; if an addon has already been added, it will skip any other requests to add it. The problem comes when this first addon is added but it's empty. It shows up on the list as added, but nothing was really added, as the folder itself wasn't found. This can happen when PG parses dependcies of a local addon; I guess it expects all the dependencies to be "native" addons, but that's not always the case. Lots of local addons depend on other local addons, but PG currently just looks for depedency addons in the `OpenFrameworks/addons` folder. 

With the current implementation, if a folder does not exist with the addon name in `OpenFrameworks/addons`, PG still assumes its a valid addon, adds it to the project (which leads to nothing, as the addon has 0 files, 0 libs, etc) and puts it in the list of "added addons". This means if that later on it gets a request to add this same local addon but with the correct path (ie ../../externalAddons/ofxAnimatable), it would add the addon correctly, but bc ofxAnimatable is already on the list of added addons, its rejected and ignored... And the addon ends up not being part of the final created project.

The core of the fix is to not add addons to the projects if the folder is just not there. 

By making `fromFS()` return a bool we can indicate if it succeeded or failed to load an addon from disk. If it failed, then it was never an addon to begin with, so it should not take a spot on the "added addons" list.

Another feature of this addon is caching the result of the `fromFS()` method to RAM. This method is quite slow, as it recursivelly walks all the files in an addon directory; for example ofxOpenCV takes several seconds. Currently, if multiple addons have it as a dependency, its scanned from disk every time its listed as a dependency, leading to 90+ seconds to create a project in some cases. With this PR, if an addon is loaded/indexed from disk once (and its valid), it's cached to RAM; so the next time it's requested it can skip the disk access.

This leads to 3x faster generation on my test setup.

I also added some premptive checking of directory existance before scanning the FS to avoid ofLogError spam on the console output, which happens often when trying ot list directories that don't exist.

I tested this on windows and osx.

PS:

This PR doesn't fix the issue where local addons that have other local addons as a dependency will not get those dependencies added. Currently, "addon_config.mk" is parsed for dependencies, and for each addon listed there, it only looks inside the `OpenFrameworks/addons` folder for it. As local addons are often not there but in some other folder, they are not found this not added to the project. 

I usually keep addons that are not part of the OF release besides the OpenFrameworks folder, in a folder named "ExternalAddons". To create a project using those addons, I supply a relative path and it works great.

```
 ./projectGenerator -o"/Users/oriol/Desktop/OF_uricat/OpenFrameworks" -p"osx" -a"ofxOsc, ofxXmlSettings, ofxPoco,../../ExternalAddons/ofxAnimatable" ...
```

This is kind of hard to fix; as if ofxAnimatable has a dependency that's in "../../ExternalAddons", with the current API, PG has no way of knowing that... Unless it does some guesswork. We could look at all the paths that have been supplied for addons so far and dynamocally learn where to look for them; but I want to see what you think first. Another option is adding more CLI options to supply alternative addon locations (paths) in which to look for dependencies.

