### PR TITLE
Fix ADDON_C_SOURCES is ignored.

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -118,7 +118,9 @@ bool ofAddon::checkCorrectPlatform(ConfigParseState state){
 bool ofAddon::checkCorrectVariable(string variable, ConfigParseState state){
 	switch(state){
 	case Meta:
-		return (variable=="ADDON_NAME" || variable=="ADDON_DESCRIPTION" || variable=="ADDON_AUTHOR" || variable=="ADDON_TAGS" || variable=="ADDON_URL");
+            return std::find(AddonMetaVariables.begin(),
+                             AddonMetaVariables.end(),
+                             variable) != AddonMetaVariables.end();
 	case Common:
 	case Linux:
 	case Linux64:
@@ -132,15 +134,9 @@ bool ofAddon::checkCorrectVariable(string variable, ConfigParseState state){
 	case Emscripten:
 	case iOS:
 	case OSX:
-		return (variable == "ADDON_DEPENDENCIES" || variable == "ADDON_INCLUDES" ||
-				variable == "ADDON_CFLAGS" || variable == "ADDON_CPPFLAGS" ||
-				variable == "ADDON_LDFLAGS"  || variable == "ADDON_LIBS" || variable == "ADDON_PKG_CONFIG_LIBRARIES" ||
-				variable == "ADDON_FRAMEWORKS" ||
-				variable == "ADDON_SOURCES" || variable == "ADDON_OBJC_SOURCES" || variable == "ADDON_CPP_SOURCES" || variable == "ADDON_HEADER_SOURCES" ||
-				variable == "ADDON_DATA" ||
-				variable == "ADDON_LIBS_EXCLUDE" || variable == "ADDON_SOURCES_EXCLUDE" || variable == "ADDON_INCLUDES_EXCLUDE" || variable == "ADDON_FRAMEWORKS_EXCLUDE" ||
-				variable == "ADDON_DLLS_TO_COPY" ||
-				variable == "ADDON_DEFINES");
+            return std::find(AddonProjectVariables.begin(),
+                             AddonProjectVariables.end(),
+                             variable) != AddonProjectVariables.end();
 	case Unknown:
 	default:
 		return false;
@@ -219,7 +215,7 @@ void ofAddon::addReplaceStringVector(vector<LibraryBinary> & variable, string va
 }
 
 void ofAddon::parseVariableValue(string variable, string value, bool addToValue, string line, int lineNum){
-	if(variable == "ADDON_NAME"){
+	if(variable == ADDON_NAME){
 		if(value!=name){
 			ofLogError() << "Error parsing " << name << " addon_config.mk" << "\n\t\t"
 						<< "line " << lineNum << ": " << line << "\n\t\t"
@@ -233,103 +229,103 @@ void ofAddon::parseVariableValue(string variable, string value, bool addToValue,
 	if (!isLocalAddon) addonRelPath = ofFilePath::addTrailingSlash(pathToOF) + "addons/" + name;
 	else addonRelPath = addonPath;
 
-	if(variable == "ADDON_DESCRIPTION"){
+	if(variable == ADDON_DESCRIPTION){
 		addReplaceString(description,value,addToValue);
 		return;
 	}
 
-	if(variable == "ADDON_AUTHOR"){
+	if(variable == ADDON_AUTHOR){
 		addReplaceString(author,value,addToValue);
 		return;
 	}
 
-	if(variable == "ADDON_TAGS"){
+	if(variable == ADDON_TAGS){
 		addReplaceStringVector(tags,value,"",addToValue);
 		return;
 	}
 
-	if(variable == "ADDON_URL"){
+	if(variable == ADDON_URL){
 		addReplaceString(url,value,addToValue);
 		return;
 	}
 
-	if(variable == "ADDON_DEPENDENCIES"){
+	if(variable == ADDON_DEPENDENCIES){
 		addReplaceStringVector(dependencies,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_INCLUDES"){
+	if(variable == ADDON_INCLUDES){
 		addReplaceStringVector(includePaths,value,addonRelPath,addToValue);
 	}
 
-	if(variable == "ADDON_CFLAGS"){
+	if(variable == ADDON_CFLAGS){
 		addReplaceStringVector(cflags,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_CPPFLAGS"){
+	if(variable == ADDON_CPPFLAGS){
 		addReplaceStringVector(cppflags,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_LDFLAGS"){
+	if(variable == ADDON_LDFLAGS){
 		addReplaceStringVector(ldflags,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_LIBS"){
+	if(variable == ADDON_LIBS){
 		addReplaceStringVector(libs,value,addonRelPath,addToValue);
 	}
 
-	if(variable == "ADDON_DLLS_TO_COPY"){
+	if(variable == ADDON_DLLS_TO_COPY){
 		addReplaceStringVector(dllsToCopy,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_PKG_CONFIG_LIBRARIES"){
+	if(variable == ADDON_PKG_CONFIG_LIBRARIES){
 		addReplaceStringVector(pkgConfigLibs,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_FRAMEWORKS"){
+	if(variable == ADDON_FRAMEWORKS){
 		addReplaceStringVector(frameworks,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_SOURCES"){
+	if(variable == ADDON_SOURCES){
 		addReplaceStringVector(srcFiles,value,addonRelPath,addToValue);
 	}
 
-	if(variable == "ADDON_C_SOURCES"){
+	if(variable == ADDON_C_SOURCES){
 		addReplaceStringVector(csrcFiles,value,addonRelPath,addToValue);
 	}
 
-	if(variable == "ADDON_CPP_SOURCES"){
+	if(variable == ADDON_CPP_SOURCES){
 		addReplaceStringVector(cppsrcFiles,value,addonRelPath,addToValue);
 	}
 
-	if(variable == "ADDON_HEADER_SOURCES"){
+	if(variable == ADDON_HEADER_SOURCES){
 		addReplaceStringVector(headersrcFiles,value,addonRelPath,addToValue);
 	}
 
-	if(variable == "ADDON_OBJC_SOURCES"){
+	if(variable == ADDON_OBJC_SOURCES){
 		addReplaceStringVector(objcsrcFiles,value,addonRelPath,addToValue);
 	}
 
-	if(variable == "ADDON_DATA"){
+	if(variable == ADDON_DATA){
 		addReplaceStringVector(data,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_LIBS_EXCLUDE"){
+	if(variable == ADDON_LIBS_EXCLUDE){
 		addReplaceStringVector(excludeLibs,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_SOURCES_EXCLUDE"){
+	if(variable == ADDON_SOURCES_EXCLUDE){
 		addReplaceStringVector(excludeSources,value,"",addToValue);
 	}
 
-	if(variable == "ADDON_INCLUDES_EXCLUDE"){
+	if(variable == ADDON_INCLUDES_EXCLUDE){
 		addReplaceStringVector(excludeIncludes,value,"",addToValue);
 	}
 
-	if (variable == "ADDON_FRAMEWORKS_EXCLUDE") {
+	if (variable == ADDON_FRAMEWORKS_EXCLUDE) {
 		addReplaceStringVector(excludeFrameworks, value, "", addToValue);
 	}
 
-	if (variable == "ADDON_DEFINES") {
+	if (variable == ADDON_DEFINES) {
 		addReplaceStringVector(defines, value, "", addToValue);
 	}
 }

--- a/ofxProjectGenerator/src/addons/ofAddon.h
+++ b/ofxProjectGenerator/src/addons/ofAddon.h
@@ -12,6 +12,81 @@
 #include "ofConstants.h"
 #include "LibraryBinary.h"
 
+// About Metadata
+
+const std::string ADDON_NAME = "ADDON_NAME";
+const std::string ADDON_DESCRIPTION = "ADDON_DESCRIPTION";
+const std::string ADDON_AUTHOR = "ADDON_AUTHOR";
+const std::string ADDON_TAGS = "ADDON_TAGS";
+const std::string ADDON_URL = "ADDON_URL";
+
+const std::vector<std::string> AddonMetaVariables = {
+    ADDON_NAME,
+    ADDON_DESCRIPTION,
+    ADDON_AUTHOR,
+    ADDON_TAGS,
+    ADDON_URL,
+};
+
+// About Project settings
+
+// About Build Settings
+const std::string ADDON_DEPENDENCIES = "ADDON_DEPENDENCIES";
+const std::string ADDON_INCLUDES = "ADDON_INCLUDES";
+const std::string ADDON_CFLAGS = "ADDON_CFLAGS";
+const std::string ADDON_CPPFLAGS = "ADDON_CPPFLAGS";
+const std::string ADDON_LDFLAGS = "ADDON_LDFLAGS";
+const std::string ADDON_LIBS = "ADDON_LIBS";
+const std::string ADDON_DEFINES = "ADDON_DEFINES";
+
+// About Source Codes
+const std::string ADDON_SOURCES = "ADDON_SOURCES";
+const std::string ADDON_HEADER_SOURCES = "ADDON_HEADER_SOURCES";
+const std::string ADDON_C_SOURCES = "ADDON_C_SOURCES";
+const std::string ADDON_CPP_SOURCES = "ADDON_CPP_SOURCES";
+const std::string ADDON_OBJC_SOURCES = "ADDON_OBJC_SOURCES";
+
+// About Exclude
+const std::string ADDON_LIBS_EXCLUDE = "ADDON_LIBS_EXCLUDE";
+const std::string ADDON_SOURCES_EXCLUDE = "ADDON_SOURCES_EXCLUDE";
+const std::string ADDON_INCLUDES_EXCLUDE = "ADDON_INCLUDES_EXCLUDE";
+const std::string ADDON_FRAMEWORKS_EXCLUDE = "ADDON_FRAMEWORKS_EXCLUDE";
+
+const std::string ADDON_DATA = "ADDON_DATA";
+
+// About Env Specific
+const std::string ADDON_PKG_CONFIG_LIBRARIES = "ADDON_PKG_CONFIG_LIBRARIES";
+const std::string ADDON_FRAMEWORKS = "ADDON_FRAMEWORKS";
+const std::string ADDON_DLLS_TO_COPY = "ADDON_DLLS_TO_COPY";
+
+const std::vector<std::string> AddonProjectVariables = {
+    ADDON_DEPENDENCIES,
+    
+    ADDON_INCLUDES,
+    ADDON_CFLAGS,
+    ADDON_CPPFLAGS,
+    ADDON_LDFLAGS,
+    ADDON_LIBS,
+    ADDON_DEFINES,
+    
+    ADDON_SOURCES,
+    ADDON_HEADER_SOURCES,
+    ADDON_C_SOURCES,
+    ADDON_CPP_SOURCES,
+    ADDON_OBJC_SOURCES,
+    
+    ADDON_LIBS_EXCLUDE,
+    ADDON_SOURCES_EXCLUDE,
+    ADDON_INCLUDES_EXCLUDE,
+    ADDON_FRAMEWORKS_EXCLUDE,
+    
+    ADDON_DATA,
+    
+    ADDON_PKG_CONFIG_LIBRARIES,
+    ADDON_FRAMEWORKS,
+    ADDON_DLLS_TO_COPY,
+};
+
 class ofAddon {
 
 public:


### PR DESCRIPTION
This PR fixed bug ADDON_C_SOURCES is ignored.
with replacing too long connection likes `variable == "VARIABLE" || variable == "VARIABLE"  || variable == "VARIABLE" || ...` to declare vector of variable and using `std::find`.

This update makes be clear declarations by `std::vector<std::string>` at the top of the header file. 
I think it is good as a kind of self-documentation.

And replace magic number like "VARIABLE_NAME" with std::string VARIABLE_NAME = "VARIABLE_NAME".
Those strings are used only twice but I believe to making constant variables guarantee the same value.
