### PR TITLE
fix(C++17): Compatibility with C++17 on of-HEAD

### DIFF
--- a/ofxProjectGenerator/src/projects/visualStudioProject.cpp
+++ b/ofxProjectGenerator/src/projects/visualStudioProject.cpp
@@ -447,7 +447,8 @@ void visualStudioProject::addAddon(ofAddon & addon){
 
 	for(int i=0;i<(int)addon.dllsToCopy.size();i++){
 		ofLogVerbose() << "adding addon dlls to bin: " << addon.dllsToCopy[i];
-		std::string dll = std::filesystem::absolute(addon.dllsToCopy[i], addon.addonPath).string();
+        auto sep = std::filesystem::path("/").make_preferred();
+        std::string dll = std::filesystem::absolute(addon.addonPath + sep.string() + addon.dllsToCopy[i]).string();
 		ofFile(dll).copyTo(ofFilePath::join(projectDir,"bin/"),false,true);
 	}
 


### PR DESCRIPTION
Without these lines, projectGenerator fails to compile on linux with c++17 Compatibility changes.

These changes were mentioned in [this](https://github.com/openframeworks/openFrameworks/issues/6585) thread