### PR TITLE
fix config.make to use relative OF_ROOT if project is inside OF folder

### DIFF
--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -217,7 +217,13 @@ bool baseProject::save(){
 
 			//add the of root path
 			if( str.rfind("# OF_ROOT =", 0) == 0 ){
-				saveConfig << "OF_ROOT = " + getOFRoot() << endl;
+   
+                            auto path = getOFRoot();
+                            if( projectDir.string().rfind(getOFRoot(),0) == 0 ){
+                                path = getOFRelPath(projectDir);
+                            }
+                            
+                            saveConfig << "OF_ROOT = " << path << endl;
 			}
 			// replace this section with our external paths
 			else if( extSrcPaths.size() && str.rfind("# PROJECT_EXTERNAL_SOURCE_PATHS =", 0) == 0 ){


### PR DESCRIPTION
This addresses the issue here:
https://forum.openframeworks.cc/t/using-of-with-vscode-on-windows/41676/2 

And probably will address some other issues where examples work but projects don't. 
It makes OF_ROOT relative if the project exists inside the OF folder. 

ie for most projects in `apps/myapps/` OF_ROOT will now be `../../../` - currently it was hard coding the full absolute path which means if you moved your OF folder the project would break. 

Wondering if there might be other instances ( in other project file generation ) where we should be using relative paths and we are using absolute. 