### PR TITLE
XCode - addons with correct paths now

### DIFF
--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -47,7 +47,7 @@ bool isPlatformName(std::string file){
 }
 
 std::unique_ptr<baseProject::Template> baseProject::parseTemplate(const ofDirectory & templateDir){
-	auto name = ofFilePath::getBaseName(templateDir.getOriginalDirectory());
+	auto name = of::filesystem::path(templateDir.getOriginalDirectory()).parent_path().filename();
 	if(templateDir.isDirectory() && !isPlatformName(name)){
 		ofBuffer templateconfig;
 		ofFile templateconfigFile(ofFilePath::join(templateDir.path(), "template.config"));
@@ -140,7 +140,6 @@ bool baseProject::create(const of::filesystem::path & _path, std::string templat
 		ofDirectory templateDir(ofFilePath::join(getOFRoot(),templatesFolder + templateName));
 		templateDir.setShowHidden(true);
 		auto templateConfig = parseTemplate(templateDir);
-		cout << ">>> TEMPLATE " << name << endl;
 		if(templateConfig){
 			ofDirectory project(projectDir);
 			recursiveTemplateCopy(templateDir,project);

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -136,9 +136,11 @@ bool baseProject::create(const of::filesystem::path & _path, std::string templat
 	if(!ret) return false;
 
 	if(templateName!=""){
+		auto name = ofFilePath::join(getOFRoot(),templatesFolder + templateName);
 		ofDirectory templateDir(ofFilePath::join(getOFRoot(),templatesFolder + templateName));
 		templateDir.setShowHidden(true);
 		auto templateConfig = parseTemplate(templateDir);
+		cout << ">>> TEMPLATE " << name << endl;
 		if(templateConfig){
 			ofDirectory project(projectDir);
 			recursiveTemplateCopy(templateDir,project);

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -127,7 +127,7 @@ bool xcodeProject::createProjectFile(){
 	}
 
 	// make everything relative the right way.
-	string relRoot = getOFRelPathFS(projectDir).string();
+	relRoot = getOFRelPathFS(projectDir).string();
 	projectDir = projectDir.lexically_normal();
         
         //projectDir is always absolute at the moment
@@ -217,7 +217,8 @@ string xcodeProject::getFolderUUID(string folder) {
 
 					// here we add an UUID for the group (folder) and we initialize an array to receive children (files or folders inside)
 					commands.emplace_back("Add :objects:"+thisUUID+":isa string PBXGroup");
-					commands.emplace_back("Add :objects:"+thisUUID+":name string "+folders[a]);
+					commands.emplace_back("Add :objects:"+thisUUID+":path string " + relRoot + "/" + fullPath);
+					commands.emplace_back("Add :objects:"+thisUUID+":name string " + folders[a]);
 					commands.emplace_back("Add :objects:"+thisUUID+":children array");
 //					commands.emplace_back("Add :objects:"+thisUUID+":sourceTree string <group>");
 					commands.emplace_back("Add :objects:"+thisUUID+":sourceTree string SOURCE_ROOT");
@@ -452,7 +453,8 @@ void xcodeProject::addFramework(string name, string path, string folder){
 
 	// we add one of the build refs to the list of frameworks
 	// TENTATIVA desesperada aqui...
-	string folderUUID = getFolderUUID(folder);
+	string folderUUID = generateUUID(folder);
+//	string folderUUID = getFolderUUID(folder);
 	commands.emplace_back("Add :objects:"+folderUUID+":children: string " + UUID);
 
 	//commands.emplace_back("Add :objects:"+frameworksUUID+":children array");

--- a/ofxProjectGenerator/src/projects/xcodeProject.cpp
+++ b/ofxProjectGenerator/src/projects/xcodeProject.cpp
@@ -197,7 +197,7 @@ void xcodeProject::renameProject(){ //base
 	}
 }
 
-string xcodeProject::getFolderUUID(string folder) {
+string xcodeProject::getFolderUUID(string folder, bool isFolder) {
 	string UUID = "";
 	if ( folderUUID.find(folder) == folderUUID.end() ) { // NOT FOUND
 		vector < string > folders = ofSplitString(folder, "/", true);
@@ -217,7 +217,9 @@ string xcodeProject::getFolderUUID(string folder) {
 
 					// here we add an UUID for the group (folder) and we initialize an array to receive children (files or folders inside)
 					commands.emplace_back("Add :objects:"+thisUUID+":isa string PBXGroup");
-					commands.emplace_back("Add :objects:"+thisUUID+":path string " + relRoot + "/" + fullPath);
+					if (isFolder) {
+						commands.emplace_back("Add :objects:"+thisUUID+":path string " + relRoot + "/" + fullPath);
+					}
 					commands.emplace_back("Add :objects:"+thisUUID+":name string " + folders[a]);
 					commands.emplace_back("Add :objects:"+thisUUID+":children array");
 //					commands.emplace_back("Add :objects:"+thisUUID+":sourceTree string <group>");
@@ -453,8 +455,7 @@ void xcodeProject::addFramework(string name, string path, string folder){
 
 	// we add one of the build refs to the list of frameworks
 	// TENTATIVA desesperada aqui...
-	string folderUUID = generateUUID(folder);
-//	string folderUUID = getFolderUUID(folder);
+	string folderUUID = getFolderUUID(folder, false);
 	commands.emplace_back("Add :objects:"+folderUUID+":children: string " + UUID);
 
 	//commands.emplace_back("Add :objects:"+frameworksUUID+":children array");
@@ -498,7 +499,7 @@ void xcodeProject::addFramework(string name, string path, string folder){
 	// finally, this is for making folders based on the frameworks position in the addon. so it can appear in the sidebar / file explorer
 
 	if (folder.size() > 0 && !ofIsStringInString(folder, "/System/Library/Frameworks")){
-		string folderUUID = getFolderUUID(folder);
+		string folderUUID = getFolderUUID(folder, false);
 	} else {
 		//FIXME: else what?
 	}

--- a/ofxProjectGenerator/src/projects/xcodeProject.h
+++ b/ofxProjectGenerator/src/projects/xcodeProject.h
@@ -65,7 +65,7 @@ public:
 	std::map <string, string> folderUUID = {
 	};
 
-	string getFolderUUID(string folder);
+	string getFolderUUID(string folder, bool isFolder = true);
 	
 	string relRoot = "../../..";
 };

--- a/ofxProjectGenerator/src/projects/xcodeProject.h
+++ b/ofxProjectGenerator/src/projects/xcodeProject.h
@@ -66,4 +66,6 @@ public:
 	};
 
 	string getFolderUUID(string folder);
+	
+	string relRoot = "../../..";
 };


### PR DESCRIPTION
In XCode if you click any addon folder, now it has the correct location.
if you right click -> show in finder it will open the correct folder.

And it won't create a path if it is a framework, so we don't have a broken link there.


EDIT: this also fix one issue about PG not generating other templates like vscode.

