### PR TITLE
PG : fix local_addons

### DIFF
--- a/ofxProjectGenerator/src/addons/ofAddon.cpp
+++ b/ofxProjectGenerator/src/addons/ofAddon.cpp
@@ -12,7 +12,14 @@
 //#include "Poco/RegularExpression.h"
 #include <list>
 #include <regex>
-using namespace std;
+
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
+using std::list;
+
+namespace fs = of::filesystem;
 
 vector<string> splitStringOnceByLeft(const string &source, const string &delimiter) {
 	size_t pos = source.find(delimiter);

--- a/ofxProjectGenerator/src/projects/baseProject.cpp
+++ b/ofxProjectGenerator/src/projects/baseProject.cpp
@@ -264,7 +264,7 @@ void baseProject::addAddon(std::string addonName){
 	bool inCache = isAddonInCache(addonName, target);
 	//inCache = false; //to test no-cache scenario
 
-	if (ofDirectory(addonName).exists()){
+	if (of::filesystem::exists(addonName)) {
 		// if it's an absolute path, convert to relative...
 		string relativePath = ofFilePath::makeRelative(addon.pathToProject, addonName);
 		addonName = relativePath;


### PR DESCRIPTION
this condition will never be fullfilled in PG
```c++
if (ofDirectory(addonName).exists())
```
because it gets the addon name, lets say ofxAssimpModelLoader
and look up relative to PG data folder, because ofDirectory translates to relative to data path
this can be checked by this command
```c++
	cout << ofDirectory(addonName).path() << endl;
```
and the result is ../../projectGenerator/commandLine/bin/data/ofxAssimpModelLoader/

this is meant to fix local_addons.
It is possible there are other underlying issues because this block was not executing at all.

