### PR TITLE
buildPG.sh updates

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         path: |
           openFrameworks
-        key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('**/*.cpp') }}
+        key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('openFrameworks/**/*.cpp') }}
         restore-keys: |
           ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-          
     - name: rm-dev

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,6 +31,9 @@ jobs:
       with:
         path: |
           openFrameworks
+      key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('**/*.cpp') }}
+      restore-keys: |
+          ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-          
     - name: rm-dev
       run: sudo rm -rf /Library/Developer
     - name: Build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,7 +30,7 @@ jobs:
         cache-name: cache-keep-of
       with:
         path: |
-          openFrameworks/**
+          /Users/runner/work/projectGenerator/openFrameworks/**
         key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('openFrameworks/**/*.cpp') }}
         restore-keys: |
           ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-          

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,6 +23,14 @@ jobs:
      TARGET: ${{matrix.cfg.target}}
     steps:
     - uses: actions/checkout@v3
+    - name: Cache OF
+      id: cache-of
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-keep-of
+      with:
+        path: |
+          openFrameworks
     - name: rm-dev
       run: sudo rm -rf /Library/Developer
     - name: Build

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,7 +30,7 @@ jobs:
         cache-name: cache-keep-of
       with:
         path: |
-          openFrameworks
+          openFrameworks/**
         key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('openFrameworks/**/*.cpp') }}
         restore-keys: |
           ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-          

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,8 +31,8 @@ jobs:
       with:
         path: |
           openFrameworks
-      key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('**/*.cpp') }}
-      restore-keys: |
+        key: ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-${{ hashFiles('**/*.cpp') }}
+        restore-keys: |
           ${{ runner.os }}-${{matrix.cfg.opt}}-${{ env.cache-name }}-          
     - name: rm-dev
       run: sudo rm -rf /Library/Developer

--- a/commandLine/Project.xcconfig
+++ b/commandLine/Project.xcconfig
@@ -5,6 +5,15 @@ OF_PATH = ../../..
 //THIS HAS ALL THE HEADER AND LIBS FOR OF CORE
 #include "../../../libs/openFrameworksCompiled/project/osx/CoreOF.xcconfig"
 
+HEADER_OF = "$(OF_PATH)/libs/openFrameworks/{ofMain.h}"
+
+
+OF_CORE_LIBS = $(LIB_GLEW) $(LIB_PUGIXML)
+
+OF_CORE_HEADERS = $(HEADER_OF) $(HEADER_GLEW) $(HEADER_TESS2) $(HEADER_GLFW) $(HEADER_UTF8) $(HEADER_JSON) $(HEADER_GLM) $(HEADER_PUGIXML)
+
+OF_CORE_FRAMEWORKS = -framework Accelerate -framework Cocoa -framework CoreFoundation -framework CoreServices -framework CoreVideo -framework IOKit -framework OpenGL -framework QuartzCore -framework Security
+
 //UNCOMMENT BELOW TO ENABLE C++ 17 and std::filesystem
 CLANG_CXX_LANGUAGE_STANDARD = c++17
 MACOSX_DEPLOYMENT_TARGET = 10.15

--- a/commandLine/commandLine.xcodeproj/project.pbxproj
+++ b/commandLine/commandLine.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -660,10 +660,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = E4B69B5F0A3A1757003C02F2 /* Build configuration list for PBXNativeTarget "commandLine" */;
 			buildPhases = (
-				E42962A92163ECCD00A6A9E2 /* ShellScript */,
+				E42962A92163ECCD00A6A9E2 /* Run Script - Compile OF */,
 				E4B69B580A3A1756003C02F2 /* Sources */,
 				E4B69B590A3A1756003C02F2 /* Frameworks */,
-				E4B6FFFD0C3F9AB9008CF71C /* ShellScript */,
 				E4C2427710CC5ABF004149E2 /* CopyFiles */,
 				928F60851B6710B200E2D791 /* ShellScript */,
 			);
@@ -707,6 +706,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		928F60851B6710B200E2D791 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -716,33 +716,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\" \"$TARGET_BUILD_DIR/commandLine\";\t\n#echo mv \"$TARGET_BUILD_DIR/commandLinePG\" \"$TARGET_BUILD_DIR/projectGenerator\"\ncp \"$TARGET_BUILD_DIR/commandLine\" \"$TARGET_BUILD_DIR/projectGenerator\"\nrm \"$TARGET_BUILD_DIR/commandLine\"\n";
+			shellScript = "cp \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/MacOS/$PRODUCT_NAME\" \"$TARGET_BUILD_DIR/projectGenerator\";\t\n";
+			showEnvVarsInLog = 0;
 		};
-		E42962A92163ECCD00A6A9E2 /* ShellScript */ = {
+		E42962A92163ECCD00A6A9E2 /* Run Script - Compile OF */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Run Script - Compile OF";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "xcodebuild -project \"$OF_PATH/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj\" -target openFrameworks -configuration \"${CONFIGURATION}\"  CLANG_CXX_LANGUAGE_STANDARD=$CLANG_CXX_LANGUAGE_STANDARD MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET\n";
-		};
-		E4B6FFFD0C3F9AB9008CF71C /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n# Copy default icon file into App/Resources\necho 'icon file'\necho $ICON_FILE\necho 'target build dir'\necho $TARGET_BUILD_DIR\necho rsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n\n#rsync -aved \"$ICON_FILE\" \"$TARGET_BUILD_DIR/$PRODUCT_NAME.app/Contents/Resources/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -1,4 +1,4 @@
-#include "ofMain.h"
+//#include "ofMain.h"
 #include "optionparser.h"
 #include "defines.h"
 enum  optionIndex { UNKNOWN, HELP, PLUS, RECURSIVE, LISTTEMPLATES, PLATFORMS, ADDONS, OFPATH, VERBOSE, TEMPLATE, DRYRUN, SRCEXTERNAL, VERSION};

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -156,33 +156,37 @@ if [ $ret -ne 0 ]; then
       exit 1
 fi
 
-# install electron sign globally
-sudo npm install -g electron-osx-sign
 
-if [ -d "/Users/runner/" ]; then
-    sudo chown -R 501:20 "/Users/runner/.npm"
-fi    
 
-import_certificate
 
-# Generate electron app
-cd ${pg_root}/frontend
-npm update
-npm install > /dev/null
-npm run build:osx > /dev/null
-mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-osx
-sign_and_upload osx
 
-cd ${pg_root}/frontend
-npm run build:osx > /dev/null
-mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-ios
-sign_and_upload ios
+# # install electron sign globally
+# sudo npm install -g electron-osx-sign
 
-cd ${pg_root}/frontend
-npm run build:osx > /dev/null
-mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-android
-sign_and_upload android
+# if [ -d "/Users/runner/" ]; then
+#     sudo chown -R 501:20 "/Users/runner/.npm"
+# fi    
 
-rm -rf scripts/id_rsa 2> /dev/null
-rm -rf scripts/*.p12 2> /dev/null
+# import_certificate
+
+# # Generate electron app
+# cd ${pg_root}/frontend
+# npm update
+# npm install > /dev/null
+# npm run build:osx > /dev/null
+# mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-osx
+# sign_and_upload osx
+
+# cd ${pg_root}/frontend
+# npm run build:osx > /dev/null
+# mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-ios
+# sign_and_upload ios
+
+# cd ${pg_root}/frontend
+# npm run build:osx > /dev/null
+# mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-android
+# sign_and_upload android
+
+# rm -rf scripts/id_rsa 2> /dev/null
+# rm -rf scripts/*.p12 2> /dev/null
 

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -188,7 +188,7 @@ rm -rf scripts/id_rsa 2> /dev/null
 rm -rf scripts/*.p12 2> /dev/null
 
 
-pwd 
-ls -alfR
-cd ..
-pwd 
+# pwd 
+# ls -alfR
+# cd ..
+# pwd 

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -130,6 +130,8 @@ pg_root=${PWD}/openFrameworks/apps/projectGenerator
 
 if [ -d "openframeworks/.git" ]; then
     echo 'OF already cloned, using it'
+    # cd openframeworks 
+    # git pull
   # Control will enter here if $DIRECTORY exists.
 else  
     git clone --depth=1 https://github.com/openframeworks/openFrameworks
@@ -157,7 +159,7 @@ fi
 # install electron sign globally
 sudo npm install -g electron-osx-sign
 
-if [ -d "l/Users/runner/" ]; then
+if [ -d "/Users/runner/" ]; then
     sudo chown -R 501:20 "/Users/runner/.npm"
 fi    
 

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-
+pwd
 
 echoDots(){
     sleep 0.1 # Waiting for a brief period first, allowing jobs returning immediatly to finish
@@ -193,3 +193,5 @@ fi
 
 pwd 
 ls -alfR
+cd ..
+pwd 

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -128,12 +128,21 @@ cd ..
 of_root=${PWD}/openFrameworks
 pg_root=${PWD}/openFrameworks/apps/projectGenerator
 
-git clone --depth=1 https://github.com/openframeworks/openFrameworks
+if [ -d "openframeworks/.git" ]; then
+    echo 'OF already cloned, using it'
+  # Control will enter here if $DIRECTORY exists.
+else  
+    git clone --depth=1 https://github.com/openframeworks/openFrameworks
+fi
 #cp not move so github actions can do cleanup without error
 cp -r projectGenerator openFrameworks/apps/
 
 cd ${of_root}
-scripts/osx/download_libs.sh
+if [ -d "libs/glfw" ]; then
+    echo 'libs installed, using them'
+else
+    scripts/osx/download_libs.sh
+fi
 
 # Compile commandline tool
 cd ${pg_root}

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -147,14 +147,14 @@ else
 fi
 
 # Compile commandline tool
-cd ${pg_root}
-echo "Building openFrameworks PG - OSX"
-xcodebuild -configuration Release -target commandLine CODE_SIGN_IDENTITY="" UseModernBuildSystem=NO -project commandLine/commandLine.xcodeproj
-ret=$?
-if [ $ret -ne 0 ]; then
-      echo "Failed building Project Generator"
-      exit 1
-fi
+# cd ${pg_root}
+# echo "Building openFrameworks PG - OSX"
+# xcodebuild -configuration Release -target commandLine CODE_SIGN_IDENTITY="" UseModernBuildSystem=NO -project commandLine/commandLine.xcodeproj
+# ret=$?
+# if [ $ret -ne 0 ]; then
+#       echo "Failed building Project Generator"
+#       exit 1
+# fi
 
 
 

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -156,7 +156,11 @@ fi
 
 # install electron sign globally
 sudo npm install -g electron-osx-sign
-sudo chown -R 501:20 "/Users/runner/.npm"
+
+if [ -d "l/Users/runner/" ]; then
+    sudo chown -R 501:20 "/Users/runner/.npm"
+fi    
+
 import_certificate
 
 # Generate electron app

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -190,3 +190,6 @@ fi
 # rm -rf scripts/id_rsa 2> /dev/null
 # rm -rf scripts/*.p12 2> /dev/null
 
+
+pwd 
+ls -alfR

--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-pwd
-
 echoDots(){
     sleep 0.1 # Waiting for a brief period first, allowing jobs returning immediatly to finish
     while isRunning $1; do
@@ -146,49 +144,48 @@ else
     scripts/osx/download_libs.sh
 fi
 
+
 # Compile commandline tool
-# cd ${pg_root}
-# echo "Building openFrameworks PG - OSX"
-# xcodebuild -configuration Release -target commandLine CODE_SIGN_IDENTITY="" UseModernBuildSystem=NO -project commandLine/commandLine.xcodeproj
-# ret=$?
-# if [ $ret -ne 0 ]; then
-#       echo "Failed building Project Generator"
-#       exit 1
-# fi
+cd ${pg_root}
+echo "Building openFrameworks PG - OSX"
+xcodebuild -configuration Release -target commandLine CODE_SIGN_IDENTITY="" UseModernBuildSystem=NO -project commandLine/commandLine.xcodeproj
+ret=$?
+if [ $ret -ne 0 ]; then
+      echo "Failed building Project Generator"
+      exit 1
+fi
 
 
 
+# install electron sign globally
+sudo npm install -g electron-osx-sign
 
+if [ -d "/Users/runner/" ]; then
+    sudo chown -R 501:20 "/Users/runner/.npm"
+fi    
 
-# # install electron sign globally
-# sudo npm install -g electron-osx-sign
+import_certificate
 
-# if [ -d "/Users/runner/" ]; then
-#     sudo chown -R 501:20 "/Users/runner/.npm"
-# fi    
+# Generate electron app
+cd ${pg_root}/frontend
+npm update
+npm install > /dev/null
+npm run build:osx > /dev/null
+mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-osx
+sign_and_upload osx
 
-# import_certificate
+cd ${pg_root}/frontend
+npm run build:osx > /dev/null
+mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-ios
+sign_and_upload ios
 
-# # Generate electron app
-# cd ${pg_root}/frontend
-# npm update
-# npm install > /dev/null
-# npm run build:osx > /dev/null
-# mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-osx
-# sign_and_upload osx
+cd ${pg_root}/frontend
+npm run build:osx > /dev/null
+mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-android
+sign_and_upload android
 
-# cd ${pg_root}/frontend
-# npm run build:osx > /dev/null
-# mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-ios
-# sign_and_upload ios
-
-# cd ${pg_root}/frontend
-# npm run build:osx > /dev/null
-# mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-android
-# sign_and_upload android
-
-# rm -rf scripts/id_rsa 2> /dev/null
-# rm -rf scripts/*.p12 2> /dev/null
+rm -rf scripts/id_rsa 2> /dev/null
+rm -rf scripts/*.p12 2> /dev/null
 
 
 pwd 


### PR DESCRIPTION
now it checks for already cloned OF installation.
now it checks for already installed libs
so it is faster to debug npm when running locally

EDIT: I've updated the actions and added a cache for openFrameworks repository, so together with this script change we shave more time not having to clone and installing libs and compiling from scratch.
