### PR TITLE
fixes to allow PG command line to be compiled in Visual Studio

### DIFF
--- a/commandLine/commandLine.vcxproj
+++ b/commandLine/commandLine.vcxproj
@@ -56,11 +56,11 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;src\addons;src\projects;src\utils;src\uuidxx</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;src\addons;src\projects;src\utils;src\uuidxx;src\uuidxx\src</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions></AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -77,10 +77,10 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;src\addons;src\projects;src\utils;src\uuidxx</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);src;src\addons;src\projects;src\utils;src\uuidxx;src\uuidxx\src</AdditionalIncludeDirectories>
       <CompileAs>CompileAsCpp</CompileAs>
       <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
-      <AdditionalOptions></AdditionalOptions>
+      <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -120,7 +120,7 @@
     <ClInclude Include="src\projects\xcodeProject.h" />
     <ClInclude Include="src\utils\LibraryBinary.h" />
     <ClInclude Include="src\utils\Utils.h" />
-    <ClCompile Include="src\uuidxx\src\uuidxx.cpp" />
+    <ClCompile Include="src\uuidxx\src\uuidxx.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(OF_ROOT)\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj">

--- a/commandLine/commandLine.vcxproj.filters
+++ b/commandLine/commandLine.vcxproj.filters
@@ -40,6 +40,8 @@
     <ClCompile Include="src\utils\Utils.cpp">
       <Filter>src\utils</Filter>
     </ClCompile>
+    <ClCompile Include="src\uuidxx\src\uuidxx.cpp" />
+    <ClCompile Include="src\uuidxx\src\uuidxx.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="src">

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -43,7 +43,7 @@ bool isPlatformName(std::string file){
 
 std::unique_ptr<baseProject::Template> baseProject::parseTemplate(const ofDirectory & templateDir){
 	auto name = fs::path(templateDir.getOriginalDirectory()).parent_path().filename();
-	if(templateDir.isDirectory() && !isPlatformName(name)){
+	if(templateDir.isDirectory() && !isPlatformName(name.string())){
 		ofBuffer templateconfig;
 		ofFile templateconfigFile(ofFilePath::join(templateDir.path(), "template.config"));
 		if(templateconfigFile.exists()){
@@ -51,7 +51,7 @@ std::unique_ptr<baseProject::Template> baseProject::parseTemplate(const ofDirect
 			auto supported = false;
 			auto templateConfig = std::make_unique<Template>();
 			templateConfig->dir = templateDir;
-			templateConfig->name = name;
+			templateConfig->name = name.string();
 			for(auto line: templateconfig.getLines()){
 				if(ofTrim(line).front() == '#') continue;
 				auto varValue = ofSplitString(line,"+=",true,true);
@@ -121,9 +121,9 @@ bool baseProject::create(const fs::path & _path, std::string templateName){
 		path = fs::current_path() / path;
 	}
 	projectDir = path;
-	projectName = path.filename();
+	projectName = path.filename().string();
 	if (projectName == "") {
-		projectName = path.parent_path().filename();
+		projectName = path.parent_path().filename().string();
 	}
 //	cout << "path = " << path << endl;
 //	cout << "projectName = " << projectName << endl;
@@ -226,8 +226,8 @@ bool baseProject::save(){
 			if( str.rfind("# OF_ROOT =", 0) == 0 || str.rfind("OF_ROOT =", 0) == 0){
 				auto path = getOFRoot().string();
 		
-				if( projectDir.string().rfind(getOFRoot(),0) == 0 ){
-					path = getOFRelPath(projectDir);
+				if( projectDir.string().rfind(getOFRoot().string(), 0) == 0) {
+					path = getOFRelPath(projectDir.string());
 				}
 				
 				saveConfig << "OF_ROOT = " << path << std::endl;
@@ -342,7 +342,7 @@ void baseProject::addSrcRecursively(std::string srcPath){
 
 	//if the files being added are inside the OF root folder, make them relative to the folder.
 	bool bMakeRelative = false;
-	if( srcPath.find_first_of(getOFRoot()) == 0 ){
+	if( srcPath.find_first_of(getOFRoot().string()) == 0 ){
 		bMakeRelative = true;
 	}
 

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -142,8 +142,8 @@ bool xcodeProject::createProjectFile(){
 	
         //projectDir is always absolute at the moment
         //so lets check if the projectDir is inside the OF folder - if it is not make the OF path absolute
-	if( projectDir.string().rfind(getOFRoot(),0) != 0 ){
-            relRoot = getOFRoot();
+	if( projectDir.string().rfind(getOFRoot().string(), 0) != 0) {
+            relRoot = getOFRoot().string();
 	}
 	if (relRoot != "../../.."){
 		findandreplaceInTexfile(projectDir / (projectName + ".xcodeproj/project.pbxproj"), "../../..", relRoot);

--- a/commandLine/src/utils/Utils.cpp
+++ b/commandLine/src/utils/Utils.cpp
@@ -146,7 +146,7 @@ void getFilesRecursively(const fs::path & path, std::vector < string > & fileNam
 			getFilesRecursively(f, fileNames);
 		} else {
 			// FIXME - update someday to fs::path
-			fileNames.emplace_back(f);
+			fileNames.emplace_back(f.string());
 		}
 	}
 }
@@ -165,7 +165,7 @@ void getFilesRecursively(const fs::path & path, std::vector < fs::path > & fileN
 				getFilesRecursively(f, fileNames);
 			}
 		} else {
-			fileNames.emplace_back(f);
+			fileNames.emplace_back(f.string());
 		}
 	}
 }
@@ -264,7 +264,7 @@ void getPropsRecursively(const fs::path & path, std::vector < std::string > & pr
 		} else {
 			if (f.extension() == ".props") {
 //				cout << f << endl;
-				props.emplace_back(f);
+				props.emplace_back(f.string());
 			}
 		}
 	}
@@ -283,7 +283,7 @@ void getDllsRecursively(const fs::path & path, std::vector < std::string > & dll
 			if (f.extension() == ".dll") {
 				cout << "---->> getDLLs " << f << endl;;
 
-				dlls.emplace_back(f);
+				dlls.emplace_back(f.string());
 			}
 		}
 	}
@@ -295,7 +295,7 @@ void getLibsRecursively(const fs::path & path, std::vector < std::string > & lib
 	if (!fs::is_directory(path)) return;
 	for (const auto & entry : fs::directory_iterator(path)) {
 		auto f = entry.path();
-		std::vector<std::string> splittedPath = ofSplitString(f, fs::path("/").make_preferred().string());
+		std::vector<std::string> splittedPath = ofSplitString(f.string(), fs::path("/").make_preferred().string());
 
 //		ofFile temp(dir.getFile(i));
 		std::string ext = "";
@@ -334,12 +334,12 @@ void getLibsRecursively(const fs::path & path, std::vector < std::string > & lib
 			if (ext == "a" || ext == "lib" || ext == "dylib" || ext == "so" || (ext == "dll" && platform != "vs")){
 				if (platformFound){
 //					libLibs.emplace_back( f, arch, target );
-					libLibs.push_back({ f, arch, target });
+					libLibs.push_back({ f.string(), arch, target});
 
 					//TODO: THEO hack
 					if( platform == "ios" ){ //this is so we can add the osx libs for the simulator builds
 
-						std::string currentPath = f;
+						std::string currentPath = f.string();
 
 						//TODO: THEO double hack this is why we need install.xml - custom ignore ofxOpenCv
 						if( currentPath.find("ofxOpenCv") == std::string::npos ){
@@ -352,7 +352,7 @@ void getLibsRecursively(const fs::path & path, std::vector < std::string > & lib
 					}
 				}
 			} else if (ext == "h" || ext == "hpp" || ext == "c" || ext == "cpp" || ext == "cc" || ext == "cxx" || ext == "m" || ext == "mm"){
-				libFiles.emplace_back(f);
+				libFiles.emplace_back(f.string());
 			}
 		}
 	}


### PR DESCRIPTION
The command line app doesn't compile in Visual Studio without these change. 
Mostly issues with fs::path args being passed to string types. 

@dimitre maybe give a quick look over incase anything stands out? 