### PR TITLE
Addons Framework, fix path for working OK both in OF addons and local addons - macOS

### DIFF
--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -579,8 +579,6 @@ bool ofAddon::fromFS(fs::path path, const std::string & platform){
 
 	
 	for (auto & f : frameworks) {
-//		cout << f << endl;
-
 		// knowing if we are system framework or not is important....
 		bool bIsSystemFramework = false;
 		size_t foundUnixPath = f.find('/');
@@ -593,16 +591,10 @@ bool ofAddon::fromFS(fs::path path, const std::string & platform){
 		if (bIsSystemFramework){
 			; // do we need to do anything here?
 		} else {
-
-			fs::path fPath { f };
-			fs::path rel = fs::relative (f, pathToProject);
+			// if addon is local, it is relative to the project folder, and if it is not, it is related to the project folder, ex: addons/ofxSvg
+			fs::path rel = fs::relative (f, isLocalAddon ? pathToProject : pathToOF);
 			fs::path folderFS = rel.parent_path();
 			filesToFolders[f] = folderFS.string();
-
-			//			cout << "pathToProject = " << pathToProject << endl;
-//			cout << "rel " << rel << endl;
-//			cout << "folderFS " << folderFS << endl;
-//			cout << "----" << endl;
 		}
 	}
 

--- a/commandLine/src/utils/Utils.cpp
+++ b/commandLine/src/utils/Utils.cpp
@@ -232,6 +232,7 @@ void getFrameworksRecursively(const fs::path & path, std::vector < std::string >
 		
 		if (fs::is_directory(f)) {
 			if (f.extension() == ".framework") {
+//				cout << "adding framework " << f << endl;
 				frameworks.emplace_back(f.string());
 			} else {
 				if (f.filename() == fs::path("mediaAssets")) continue;


### PR DESCRIPTION
it was giving incorrect paths when using OF addons, like when you add for example ofxSyphon on traditional OF/addons/ folder.
Creating some ".." folders in xcode navigator.
now it handles well the differences between local_addons and OF ones.
