### PR TITLE
fix `local_addons` behavier

### DIFF
--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -515,7 +515,7 @@ bool ofAddon::fromFS(fs::path path, const std::string & platform){
 	// not possible today because there are string based exclusion functions
 	for (auto & s : srcFiles) {
 		fs::path folder;
-		auto srcFS = fs::path(prefixPath / fs::relative(s, containedPath));
+		auto srcFS = fs::path(prefixPath / fs::relative(s, isLocalAddon ? pathToProject : containedPath));
 		if (isLocalAddon) {
 			folder = srcFS.parent_path();
 		} else {
@@ -624,7 +624,11 @@ bool ofAddon::fromFS(fs::path path, const std::string & platform){
 	paths.sort(); //paths.unique(); // unique not needed anymore. everything is carefully inserted now.
 
 	for (auto & p : paths) {
-		includePaths.emplace_back(p.string());
+		if(isLocalAddon) {
+			includePaths.emplace_back(fs::relative(p, pathToProject));
+		} else {
+			includePaths.emplace_back(p.string());
+		}
 	}
 
 	parseConfig();

--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -625,7 +625,7 @@ bool ofAddon::fromFS(fs::path path, const std::string & platform){
 
 	for (auto & p : paths) {
 		if(isLocalAddon) {
-			includePaths.emplace_back(fs::relative(p, pathToProject));
+			includePaths.emplace_back(fs::relative(p, pathToProject).string());
 		} else {
 			includePaths.emplace_back(p.string());
 		}

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -392,9 +392,11 @@ void baseProject::addSrcRecursively(std::string srcPath){
 			string folder = ofFilePath::getEnclosingDirectory(relPathPathToAdd,false);
 			string includeFolder = folder;
 
+#if !defined(TARGET_OSX) && !defined(TARGET_IOS)
 			ofStringReplace(folder, "../", "");
-#ifdef TARGET_WIN32
+#	ifdef TARGET_WIN32
 			ofStringReplace(folder, "..\\", ""); //do both just incase someone has used linux paths on windows
+#	endif
 #endif
 			folder =  ofFilePath::removeTrailingSlash(folder);
 

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -262,8 +262,10 @@ void baseProject::addAddon(std::string addonName){
 	bool addonOK = false;
 	bool inCache = isAddonInCache(addonName, target);
 	
-	fs::path addonPath { addonName };
-	if (fs::exists(addonPath)) {
+	auto addonPath = fs::path{addonName};
+	auto addonFilePath = addon.pathToProject / addonName;
+	ofLogNotice() << addonPath.string();
+	if (fs::exists(addonFilePath)) {
 		addon.isLocalAddon = true;
 	} else {
 		addonPath = fs::path(getOFRoot()) / "addons" / addonName;

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -216,9 +216,10 @@ string xcodeProject::getFolderUUID(string folder, bool isFolder) {
 
 		if (folders.size()){
 			for (int a=0; a<folders.size(); a++) {
-				 vector <string> joinFolders;
-				 joinFolders.assign(folders.begin(), folders.begin() + (a+1));
-				 string fullPath = ofJoinString(joinFolders, "/");
+				if(folders[a] == "..") continue;
+				vector <string> joinFolders;
+				joinFolders.assign(folders.begin(), folders.begin() + (a+1));
+				string fullPath = ofJoinString(joinFolders, "/");
 
 				// folder is still not found here:
 				if ( folderUUID.find(fullPath) == folderUUID.end() ) {

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -215,8 +215,10 @@ string xcodeProject::getFolderUUID(string folder, bool isFolder) {
 		string lastFolderUUID = projRootUUID;
 
 		if (folders.size()){
-			for (int a=0; a<folders.size(); a++) {
-				if(folders[a] == "..") continue;
+			bool isParentDirectory = true;
+			for (int a=0; a < folders.size(); a++) {
+				isParentDirectory = isParentDirectory && folders[a] == "..";
+				if(isParentDirectory) continue;
 				vector <string> joinFolders;
 				joinFolders.assign(folders.begin(), folders.begin() + (a+1));
 				string fullPath = ofJoinString(joinFolders, "/");

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -229,7 +229,7 @@ string xcodeProject::getFolderUUID(string folder, bool isFolder) {
 					// here we add an UUID for the group (folder) and we initialize an array to receive children (files or folders inside)
 					commands.emplace_back("Add :objects:"+thisUUID+":isa string PBXGroup");
 					if (isFolder) {
-						if (fs::exists(fullPath)) {
+						if (fs::exists(fs::path{projectDir} / fullPath)) {
 							commands.emplace_back("Add :objects:"+thisUUID+":path string " + fullPath);
 						} else {
 							commands.emplace_back("Add :objects:"+thisUUID+":path string " + relRoot + "/" + fullPath);


### PR DESCRIPTION
related to #372

**currently, tested on only Xcode. please test other envs...**

this PR fixes problem about `local_addons` in `addons.make`
I tested with below:

addons.make:

```
ofxOsc
./local_addons/ofxPubSubOsc
../project_common_addons/ofxUDL
```

directory structure:

```
apps/
  myDevApps/
    project_common_addons/
      ofxUDL/
        ..
    pgLocalAddonsDev/
      local_addons/
        ofxPubSubOsc/
          ..
```

and generated project:

<img width="263" alt="スクリーンショット 2023-05-26 18 39 20" src="https://github.com/openframeworks/projectGenerator/assets/200899/6a69b56f-e11c-4b7b-ba97-7d62d17cb2e3">

<s>I can't fix what `..` is appeared. but I feel like it's getting better.</s> fixed!