### PR TITLE
buildPG update for subsequent running locally

### DIFF
--- a/scripts/osx/buildPG.sh
+++ b/scripts/osx/buildPG.sh
@@ -151,16 +151,19 @@ cd ..
 of_root=${PWD}/openFrameworks
 pg_root=${PWD}/openFrameworks/apps/projectGenerator
 
-# if [ -d "openframeworks/.git" ]; then
-# 	echo 'OF already cloned, using it'
-# 	cd openframeworks
-# 	git pull
-# 	cd ..
-# 	# Control will enter here if $DIRECTORY exists.
-# else
-# 	git clone --depth=1 https://github.com/openframeworks/openFrameworks
-# fi
-git clone --depth=1 https://github.com/openframeworks/openFrameworks
+if [ -d "openframeworks/.git" ]; then
+	echo 'OF already cloned, using it'
+	cd openframeworks
+	git pull
+	# git submodule init
+	# git submodule update
+	# git submodule update
+	cd ..
+	# Control will enter here if $DIRECTORY exists.
+else
+	git clone --depth=1 https://github.com/openframeworks/openFrameworks
+fi
+#git clone --depth=1 https://github.com/openframeworks/openFrameworks
 #cp not move so github actions can do cleanup without error
 cp -r projectGenerator openFrameworks/apps/
 
@@ -206,11 +209,17 @@ cd ${pg_root}/frontend
 npm update
 npm install > /dev/null
 npm run build:osx > /dev/null
+if [ -d "${pg_root}/projectGenerator-osx" ]; then
+	rm -rf ${pg_root}/projectGenerator-osx
+fi
 mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-osx
 package_app osx
 
 cd ${pg_root}/frontend
 npm run build:osx > /dev/null
+if [ -d "${pg_root}/projectGenerator-ios" ]; then
+	rm -rf ${pg_root}/projectGenerator-ios
+fi
 mv dist/projectGenerator-darwin-x64 ${pg_root}/projectGenerator-ios
 package_app ios
 


### PR DESCRIPTION
buildPG.sh now keeps openFrameworks cloned if already exists. 
(I've uncommented this part because caching is disabled in CI now. so it will always have a fresh clone there)
and in the end it tests if the projectGenerator folders already exists, remove them if they are already there before mv part.
Again this won't happen on CI, unless we use cache between sessions.
but it can help running this buildPG locally multiple times.