### PR TITLE
Fix v013 - .xib / ofPath relative / App.xcconfig

### DIFF
--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -490,11 +490,19 @@ bool ofAddon::fromFS(const fs::path & path, const string & platform){
 
 	// MARK: srcFiles to fs::path
 	// not possible today because there are string based exclusion functions
+	alert("fromFS path " + path.string());
+	fs::path srcFolder = fs::path { "local_addons" } / path.filename();
+	
+	fs::path parentFolder = path.parent_path();
+	
 	for (auto & s : srcFiles) {
 		fs::path sFS { s };
 		fs::path folder;
 		if (isLocalAddon) {
-			folder = sFS.parent_path();
+//			folder = sFS.parent_path();
+//			folder = fs::path { "local_addons" } / sFS.parent_path().filename();
+			folder = fs::path { "local_addons" } / fs::relative(sFS.parent_path(), parentFolder);
+			alert ("isLocal folder=" + folder.string(), 36);
 		} else {
 			sFS = fixPath(s);
 			s = sFS.string();
@@ -552,7 +560,8 @@ bool ofAddon::fromFS(const fs::path & path, const string & platform){
 	for (auto & s : libFiles) {
 		fs::path folder;
 		if (isLocalAddon) {
-			folder = s.parent_path();
+			folder = fs::path { "local_addons" } / fs::relative(s.parent_path(), parentFolder);
+//			alert ("isLocal folder=" + folder.string(), 36);
 		} else {
 			folder = fs::relative(s.parent_path(), getOFRoot());
 			s = fixPath(s);
@@ -575,9 +584,18 @@ bool ofAddon::fromFS(const fs::path & path, const string & platform){
 			; // do we need to do anything here?
 		} else {
 			// if addon is local, it is relative to the project folder, and if it is not, it is related to the project folder, ex: addons/ofxSvg
+			
+			// FIXME:: Cleanup the mess
 			fs::path rel = fs::relative (f, isLocalAddon ? pathToProject : pathToOF);
-			fs::path folderFS = rel.parent_path();
-			filesToFolders[f] = folderFS.string();
+			fs::path folder = rel.parent_path();
+
+			if (isLocalAddon) {
+				fs::path fFS { f };
+				folder = fs::path { "local_addons" } / fs::relative(fFS.parent_path(), parentFolder);
+			}
+
+			
+			filesToFolders[f] = folder.string();
 		}
 	}
 

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -1,4 +1,4 @@
-#define PG_VERSION "PG v012"
+#define PG_VERSION "PG v013"
 #define TARGET_NO_SOUND
 #define TARGET_NODISPLAY
 

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -1,4 +1,4 @@
-#define PG_VERSION "PG v013"
+#define PG_VERSION "PG v014"
 #define TARGET_NO_SOUND
 #define TARGET_NODISPLAY
 

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -60,8 +60,7 @@ xcodeProject::xcodeProject(string target)
 
 bool xcodeProject::createProjectFile(){
 	fs::path xcodeProject = projectDir / ( projectName + ".xcodeproj" );
-//	cout << "createProjectFile " << xcodeProject << endl;
-//	cout << "projectDir " << projectDir << endl;
+//	alert ("createProjectFile " + xcodeProject.string(), 35);
 
 	if (fs::exists(xcodeProject)) {
 		fs::remove_all(xcodeProject);
@@ -130,14 +129,27 @@ bool xcodeProject::createProjectFile(){
 	// Calculate OF Root in relation to each project (recursively);
 //	fs::path relRoot { getOFRoot() };
 
-	if (ofIsPathInPath(projectDir, getOFRoot())) {
-		setOFRoot(fs::relative(getOFRoot(), projectDir));
-//		relRoot = fs::relative(getOFRoot(), projectDir);
-//		alert ("relRoot = " + relRoot.string());
-	} else {
-//		alert ("ofIsPathInPath not");
-	}
+//	// FIXME: maybe not needed anymore
+//	if (ofIsPathInPath(projectDir, getOFRoot())) {
+//		setOFRoot(fs::relative(getOFRoot(), projectDir));
+////		relRoot = fs::relative(getOFRoot(), projectDir);
+////		alert ("relRoot = " + relRoot.string());
+//	} else {
+////		alert ("ofIsPathInPath not");
+//	}
 	
+	
+	if (fs::exists( projectDir / "App.xcconfig" )) {
+		string UUID { generateUUID( string("App.xcconfig") ) };
+		commands.emplace_back("# ---- App.xcconfig");
+		commands.emplace_back("Add :objects:"+UUID+":fileEncoding string 4");
+		commands.emplace_back("Add :objects:"+UUID+":isa string PBXFileReference");
+		commands.emplace_back("Add :objects:"+UUID+":lastKnownFileType string text.xcconfig");
+		commands.emplace_back("Add :objects:"+UUID+":path string App.xcconfig");
+		commands.emplace_back("Add :objects:"+UUID+":sourceTree string <group>");
+		commands.emplace_back("Add :objects:" + folderUUID[""] + ":children: string " + UUID);
+		commands.emplace_back("#");
+	}
 
 	
 	if (!fs::equivalent(getOFRoot(), fs::path{"../../.."})) {
@@ -386,7 +398,7 @@ void xcodeProject::addSrc(const fs::path & srcFile, const fs::path & folder, Src
 	commands.emplace_back("Add :objects:"+UUID+":name string "+name);
 	commands.emplace_back("Add :objects:"+UUID+":path string "+srcFile.string());
 	commands.emplace_back("Add :objects:"+UUID+":isa string PBXFileReference");
-	if(ext == "xib"){
+	if(ext == ".xib"){
 		commands.emplace_back("Add :objects:"+UUID+":lastKnownFileType string "+fileKind);
 	} else {
 		commands.emplace_back("Add :objects:"+UUID+":explicitFileType string "+fileKind);


### PR DESCRIPTION
Fix issue where ".xib" extension was not typed correctly
Remove ofPath relative from XCodeproject since it is already fixed in main.
App.xcconfig added to the project if exists.
