### PR TITLE
Fix18 - fix issue where OF path was incorrectly substituted (substring)

### DIFF
--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -206,7 +206,7 @@ bool isGoodOFPath(const fs::path & path) {
 
 
 void updateProject(const fs::path & path, ofTargetPlatform target, bool bConsiderParameterAddons = true) {
-//	alert("updateProject " + path.string() , 34);
+	alert("updateProject " + path.string() , 34);
 	// bConsiderParameterAddons = do we consider that the user could call update with a new set of addons
 	// either we read the addons.make file, or we look at the parameter list.
 	// if we are updating recursively, we *never* consider addons passed as parameters.

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -206,7 +206,7 @@ bool isGoodOFPath(const fs::path & path) {
 
 
 void updateProject(const fs::path & path, ofTargetPlatform target, bool bConsiderParameterAddons = true) {
-	alert("updateProject " + path.string() , 34);
+//	alert("updateProject " + path.string() , 34);
 	// bConsiderParameterAddons = do we consider that the user could call update with a new set of addons
 	// either we read the addons.make file, or we look at the parameter list.
 	// if we are updating recursively, we *never* consider addons passed as parameters.

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PG_VERSION "19"
+#define PG_VERSION "20"
 
 #include "ofAddon.h"
 #include "ofFileUtils.h"

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -173,7 +173,7 @@ bool xcodeProject::createProjectFile(){
 
 void xcodeProject::saveScheme(){
 	auto schemeFolder = projectDir / ( projectName + ".xcodeproj" ) / "xcshareddata/xcschemes";
-//	cout << "saveScheme() schemeFolder = " << schemeFolder << endl;
+//	alert ("saveScheme " + schemeFolder.string());
 
 	if (fs::exists(schemeFolder)) {
 		fs::remove_all(schemeFolder);
@@ -202,10 +202,13 @@ void xcodeProject::saveScheme(){
 }
 
 void xcodeProject::saveMakefile(){
+//	alert ("saveMakefile " , 35);
 	for (auto & f : { "Makefile", "config.make" }) {
 		fs::path fileFrom = templatePath / f;
 		fs::path fileTo = projectDir / f;
-		if (!fs::exists(fileTo)) {
+		// Always overwrite for now, so we can have the original file from template before substituting anything
+		// if (!fs::exists(fileTo))
+		{
 			fs::copy(fileFrom, fileTo, fs::copy_options::overwrite_existing);
 		}
 	}

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -157,7 +157,7 @@ bool xcodeProject::createProjectFile(){
 	
 	if (!fs::equivalent(getOFRoot(), fs::path{"../../.."})) {
 		string root = getOFRoot().string();
-		alert ("fs not equivalent to ../../.. root = " + root);
+//		alert ("fs not equivalent to ../../.. root = " + root);
 		findandreplaceInTexfile(projectDir / (projectName + ".xcodeproj/project.pbxproj"), "../../..", root);
 		findandreplaceInTexfile(projectDir / "Project.xcconfig", "../../..", root);
 		if( target == "osx" ){

--- a/commandLine/src/utils/Utils.h
+++ b/commandLine/src/utils/Utils.h
@@ -79,3 +79,15 @@ vector <fs::path> folderList (const fs::path & path);
 vector <string> fileToStrings (const fs::path & file);
 fs::path getUserHomeDir();
 std::string getPGVersion();
+
+
+/*
+ Idea: create an object to hold the origin and destination files, with renames where needed
+ and string substitution, so we can avoid opening and writing multiple times the same file, less ssd wear.
+ */
+struct fromToReplace {
+public:
+	fs::path from;
+	fs::path to;
+	std::vector <std::pair <string, string> > findReplaces;
+};


### PR DESCRIPTION
Always overwrite template Makefiles so it avoids find and replace finding "../../.." inside "../../../.."
closes https://github.com/openframeworks/projectGenerator/issues/404