### PR TITLE
DLLs path fix

### DIFF
--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -149,6 +149,10 @@ void ofAddon::addReplaceString(string & variable, string value, bool addToVariab
 }
 
 void ofAddon::addReplaceStringVector(std::vector<string> & variable, string value, string prefix, bool addToVariable){
+	
+//	alert("addReplaceStringVector val=" + value + " : prefix=" + prefix, (value == prefix) ? 33 : 32);
+	if (value == prefix) return;
+
 	vector<string> values;
 	if(value.find("\"")!=string::npos){
 		values = ofSplitString(value,"\"",true,true);
@@ -467,7 +471,7 @@ void ofAddon::parseConfig(){
 
 
 bool ofAddon::fromFS(const fs::path & path, const string & platform){
-//	alert("ofAddon::fromFS path : " + path.string());
+    // alert("ofAddon::fromFS path : " + path.string());
 	
 	clear();
 	this->platform = platform;
@@ -500,7 +504,7 @@ bool ofAddon::fromFS(const fs::path & path, const string & platform){
 //			folder = sFS.parent_path();
 //			folder = fs::path { "local_addons" } / sFS.parent_path().filename();
 			folder = fs::path { "local_addons" } / fs::relative(sFS.parent_path(), parentFolder);
-//			alert ("isLocal folder=" + folder.string(), 36);
+            // alert ("isLocal folder=" + folder.string(), 36);
 		} else {
 			sFS = fixPath(s);
 			s = sFS.string();
@@ -544,6 +548,11 @@ bool ofAddon::fromFS(const fs::path & path, const string & platform){
 		}
 		if(platform == "vs" || platform == "msys2"){
 			getDllsRecursively(libsPath, dllsToCopy, platform);
+			
+//			alert ("ofAddon dllsToCopy", 32);
+//			for (auto & d : dllsToCopy) {
+//				cout << d << endl;
+//			}
 		}
 	}
 	

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -206,7 +206,7 @@ bool isGoodOFPath(const fs::path & path) {
 
 
 void updateProject(const fs::path & path, ofTargetPlatform target, bool bConsiderParameterAddons = true) {
-//	alert("updateProject " + path.string() , 34);
+    //alert("updateProject " + path.string() , 34);
 	// bConsiderParameterAddons = do we consider that the user could call update with a new set of addons
 	// either we read the addons.make file, or we look at the parameter list.
 	// if we are updating recursively, we *never* consider addons passed as parameters.
@@ -234,6 +234,7 @@ void updateProject(const fs::path & path, ofTargetPlatform target, bool bConside
 }
 
 void recursiveUpdate(const fs::path & path, ofTargetPlatform target) {
+    // FIXME: remove
 	alert("recursiveUpdate " + path.string() );
 	if (!fs::is_directory(path)) return;
 	vector <fs::path> folders;
@@ -272,8 +273,8 @@ void recursiveUpdate(const fs::path & path, ofTargetPlatform target) {
 		}
 		setOFRoot(ofPath);
 		fs::current_path(path);
-//		alert ("ofRoot " + ofPath.string());
-//		alert ("cwd " + path.string());
+        //alert ("ofRoot " + ofPath.string());
+        //alert ("cwd " + path.string());
 
 		updateProject(path, target, false);
 	}
@@ -480,18 +481,18 @@ int main(int argc, char** argv){
 			return EXIT_USAGE;
 		}
 		
-//		alert ("ofPath before " + ofPath.string());
-//		alert ("projectPath " + projectPath.string());
+// alert ("ofPath before " + ofPath.string());
+// alert ("projectPath " + projectPath.string());
 		if (ofPath.is_relative()) {
 			ofPath = fs::canonical(fs::current_path() / ofPath);
-//			alert ("ofPath canonical " + ofPath.string());
+            //alert ("ofPath canonical " + ofPath.string());
 		}
 		
 		if (ofIsPathInPath(projectPath, ofPath)) {
 			ofPath = fs::relative(ofPath, projectPath);
 		}
 		fs::current_path(projectPath);
-//		alert ("ofPath after " + ofPath.string());
+        //alert ("ofPath after " + ofPath.string());
 		setOFRoot(ofPath);
 	}
 

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -461,6 +461,7 @@ void baseProject::addAddon(ofAddon & addon){
 
 	for (auto & a : addon.libs) {
 		ofLogVerbose() << "adding addon libs: " << a.path;
+        // FIXME: remove
 		alert ("addlibrary " + a.path, 33);
 		addLibrary(a);
 	}

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PG_VERSION "21"
+#define PG_VERSION "23"
 
 #include "ofAddon.h"
 #include "ofFileUtils.h"

--- a/commandLine/src/projects/visualStudioProject.cpp
+++ b/commandLine/src/projects/visualStudioProject.cpp
@@ -338,7 +338,7 @@ void visualStudioProject::addProps(fs::path propsFile){
 void visualStudioProject::addLibrary(const LibraryBinary & lib) {
 	
 	// TODO: in future change Library to FS
-	alert ("visualStudioProject::addLibrary " + lib.path, 36);
+//	alert ("visualStudioProject::addLibrary " + lib.path, 36);
 	auto libraryName = fs::path { lib.path };
 //	fixSlashOrder(libraryName);
 
@@ -350,7 +350,7 @@ void visualStudioProject::addLibrary(const LibraryBinary & lib) {
 	string libFolderString = libFolder.string();
 	fixSlashOrder(libFolderString);
 	
-    alert ("libFolderString " + libFolderString, 36);
+//    alert ("libFolderString " + libFolderString, 36);
     
 	auto libName = libraryName.filename();
 
@@ -372,7 +372,7 @@ void visualStudioProject::addLibrary(const LibraryBinary & lib) {
 	}
 
 	if (!libFolderString.empty()) {
-		alert("yes " + libFolderString, 34);
+//		alert("yes " + libFolderString, 34);
 		pugi::xpath_node_set addlLibsDir = doc.select_nodes((linkPath + "AdditionalLibraryDirectories").c_str());
 		
 		// FIXME:

--- a/commandLine/src/projects/visualStudioProject.cpp
+++ b/commandLine/src/projects/visualStudioProject.cpp
@@ -338,7 +338,7 @@ void visualStudioProject::addProps(fs::path propsFile){
 void visualStudioProject::addLibrary(const LibraryBinary & lib) {
 	
 	// TODO: in future change Library to FS
-//	alert ("visualStudioProject::addLibrary " + lib.path, 36);
+	alert ("visualStudioProject::addLibrary " + lib.path, 36);
 	auto libraryName = fs::path { lib.path };
 //	fixSlashOrder(libraryName);
 
@@ -350,6 +350,8 @@ void visualStudioProject::addLibrary(const LibraryBinary & lib) {
 	string libFolderString = libFolder.string();
 	fixSlashOrder(libFolderString);
 	
+    alert ("libFolderString " + libFolderString, 36);
+    
 	auto libName = libraryName.filename();
 
 	// ---------| invariant: libExtension is `lib`
@@ -370,7 +372,7 @@ void visualStudioProject::addLibrary(const LibraryBinary & lib) {
 	}
 
 	if (!libFolderString.empty()) {
-//		alert("yes " + libFolderString, 34);
+		alert("yes " + libFolderString, 34);
 		pugi::xpath_node_set addlLibsDir = doc.select_nodes((linkPath + "AdditionalLibraryDirectories").c_str());
 		
 		// FIXME:
@@ -531,10 +533,22 @@ void visualStudioProject::addAddon(ofAddon & addon) {
 
 	for (auto & d : addon.dllsToCopy) {
 		ofLogVerbose() << "adding addon dlls to bin: " << d;
-		fs::path from = addon.addonPath / d;
-		fs::path to = projectDir / "bin" / from.filename();
-//		alert("copy from to " + from.string() + " : " + to.string());
-		fs::copy_file(from, to, fs::copy_options::overwrite_existing);
+//		fs::path from = addon.addonPath / d;
+		fs::path from { d };
+		fs::path to { projectDir / "bin" / from.filename() };
+		
+//		alert("copy from to " + from.string() + " : " + to.string(), 35);
+//		alert("addonPath " + addon.addonPath.string(), 36);
+//		alert("d " + d, 36);
+//		alert("copy from " + from.string(), 35);
+//		alert("copy to " + to.string(), 35);
+
+		
+		try {
+			fs::copy_file(from, to, fs::copy_options::overwrite_existing);
+		} catch(fs::filesystem_error& e) {
+			ofLogError(LOG_NAME) << "error copying template file " << from << endl << "to: " << to << endl <<  e.what();
+		}
 	}
 
 	


### PR DESCRIPTION
Changes in PG to address this issue
https://github.com/openframeworks/openFrameworks/issues/7652

Fixing this one will cause one issue on this another one:
https://github.com/leadedge/ofxNDI/
that can be fixed by removing this lines
```
ADDON_DLLS_TO_COPY =
ADDON_DLLS_TO_COPY += libs/NDI/export/vs/x64/Processing.NDI.Lib.x64.dll
ADDON_DLLS_TO_COPY += libs/NDI/export/vs/Win32/Processing.NDI.Lib.x86.dll
```

If we go this route I can make a PR to ofxNDI addon to ask for changes. 
thoughts @ofTheo ? 
