### PR TITLE
Fix backslash path in MSYS2

### DIFF
--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -263,13 +263,13 @@ bool baseProject::save(){
 			if( projectDir.string().rfind(getOFRoot().string(), 0) == 0) {
 				path = getOFRelPath(projectDir);
 			}
-			saveConfig << "OF_ROOT = " << path.string() << std::endl;
+			saveConfig << "OF_ROOT = " << path.generic_string() << std::endl;
 		}
 		// replace this section with our external paths
 		else if( extSrcPaths.size() && str.rfind("# PROJECT_EXTERNAL_SOURCE_PATHS =", 0) == 0 ){
 			for(int d = 0; d < extSrcPaths.size(); d++){
-				ofLog(OF_LOG_VERBOSE) << " adding PROJECT_EXTERNAL_SOURCE_PATHS to config" << extSrcPaths[d] << std::endl;
-				saveConfig << "PROJECT_EXTERNAL_SOURCE_PATHS" << (d == 0 ? " = " : " += ") << extSrcPaths[d] << std::endl;
+				ofLog(OF_LOG_VERBOSE) << " adding PROJECT_EXTERNAL_SOURCE_PATHS to config" << extSrcPaths[d].generic_string() << std::endl;
+				saveConfig << "PROJECT_EXTERNAL_SOURCE_PATHS" << (d == 0 ? " = " : " += ") << extSrcPaths[d].generic_string() << std::endl;
 			}
 		} else {
 		   saveConfig << str << std::endl;

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -519,7 +519,7 @@ void baseProject::addSrcRecursively(const fs::path & srcPath){
 	fs::path base = srcPath.parent_path();
 //	alert("base = " + base.string());
 	
-	extSrcPaths.emplace_back(srcPath.string());
+	extSrcPaths.emplace_back(srcPath);
 	vector < fs::path > srcFilesToAdd;
 	getFilesRecursively(srcPath, srcFilesToAdd);
 //	bool isRelative = ofIsPathInPath(fs::absolute(srcPath), getOFRoot());

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -92,7 +92,7 @@ protected:
 	bool recursiveCopy(const fs::path & srcDir, const fs::path & destDir);
 
 	std::vector<ofAddon> addons;
-	std::vector<std::string> extSrcPaths;
+	std::vector<fs::path> extSrcPaths;
 
 	//cached addons - if an addon is requested more than once, avoid loading from disk as it's quite slow
 	std::unordered_map<std::string,std::unordered_map<std::string, ofAddon>> addonsCache; //indexed by [platform][supplied path]


### PR DESCRIPTION
use generic_string() to write paths to config.make