### PR TITLE
VSCode as default for linux / msys2

### DIFF
--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -507,13 +507,13 @@ int main(int argc, char** argv){
 
 			for (auto & t : targets) {
 				ofLogNotice() << "-----------------------------------------------";
+				ofLogNotice() << "target platform is: " << t;
 				ofLogNotice() << "setting OF path to: " << ofPath;
 				if(busingEnvVar){
 					ofLogNotice() << "from PG_OF_PATH environment variable";
 				}else{
 					ofLogNotice() << "from -o option";
 				}
-				ofLogNotice() << "target platform is: " << t;
 				ofLogNotice() << "project path is: " << projectPath;
 				if(templateName != ""){
 					ofLogNotice() << "using additional template " << templateName;

--- a/commandLine/src/projects/CBLinuxProject.cpp
+++ b/commandLine/src/projects/CBLinuxProject.cpp
@@ -10,7 +10,7 @@
 #include "ofLog.h"
 #include "Utils.h"
 
-std::string CBLinuxProject::LOG_NAME = "CBLinuxProject";
+std::string CBLinuxProject::LOG_NAME { "CBLinuxProject" };
 
 bool CBLinuxProject::createProjectFile(){
 	// FIXME: This only exists here, not other projects. I think it should be removed

--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -112,12 +112,8 @@ bool VSCodeProject::saveProjectFile(){
 //	}
 //	alert("--- VSCodeProject::extSrcPaths() ");
 
-	json::json_pointer p = json::json_pointer("/");
-	if (workspace.data[p].is_array()) {
-		json object;
-		object["openFrameworksProjectGeneratorVersion"] = getPGVersion();
-		workspace.data[p].emplace_back( object );
-	}
+	
+	workspace.data["openFrameworksProjectGeneratorVersion"] = getPGVersion();
 	
 	workspace.save();
 	cppProperties.save();

--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -19,8 +19,8 @@ struct fileJson {
 	
 	// only works for workspace
 	void addPath(fs::path folder) {
-		json object;
 		std::string path = folder.is_absolute() ? folder.string() : "${workspaceRoot}/../" + folder.string();
+		json object;
 		object["path"] = path;
 		json::json_pointer p = json::json_pointer("/folders");
 		data[p].emplace_back( object );
@@ -112,6 +112,13 @@ bool VSCodeProject::saveProjectFile(){
 //	}
 //	alert("--- VSCodeProject::extSrcPaths() ");
 
+	json::json_pointer p = json::json_pointer("/");
+	if (workspace.data[p].is_array()) {
+		json object;
+		object["openFrameworksProjectGeneratorVersion"] = getPGVersion();
+		workspace.data[p].emplace_back( object );
+	}
+	
 	workspace.save();
 	cppProperties.save();
 	return true;

--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -38,38 +38,29 @@ struct fileJson {
 	
 	void load() {
 		std::ifstream ifs(fileName);
-		// this cause a bizarre issue. maybe it is reading after the end of the file
-//		std::string contents = ofBufferFromFile(fileName).getData();
-//		alert ("loading " + fileName.string(), 35);
 		try {
 			data = json::parse(ifs);
-//			data = json::parse(contents);
 		} catch (json::parse_error& ex) {
 			ofLogError(VSCodeProject::LOG_NAME) << "JSON parse error at byte" << ex.byte;
 		}
 	}
 	
 	void save() {
-		alert ("saving now " + fileName.string(), 33);
-		std::cout << data.dump(1, '\t') << std::endl;
-		
+//		alert ("saving now " + fileName.string(), 33);
+//		std::cout << data.dump(1, '\t') << std::endl;
 		std::ofstream jsonFile(fileName);
 		try {
 			jsonFile << data.dump(1, '\t');
 		} catch(std::exception & e) {
 			ofLogError(VSCodeProject::LOG_NAME) << "Error saving json to " << fileName << ": " << e.what();
 		}
-//		catch(...) {
-//			ofLogError(VSCodeProject::LOG_NAME) << "Error saving json to " << fileName;
-//		}
 	}
 };
 
-
 fileJson workspace;
 fileJson cppProperties;
-
 std::string VSCodeProject::LOG_NAME = "VSCodeProject";
+
 bool VSCodeProject::createProjectFile(){
 	workspace.fileName = projectDir / (projectName + ".code-workspace");
 	cppProperties.fileName = projectDir / ".vscode/c_cpp_properties.json";
@@ -101,13 +92,7 @@ bool VSCodeProject::loadProjectFile(){
 
 
 void VSCodeProject::addAddon(ofAddon & addon) {
-	alert("VSCodeProject::addAddon() " + addon.name, 35);
-	
-//	json object;
-//	std::string path = addon.addonPath.is_absolute() ? addon.addonPath.string() : "${workspaceRoot}/../" + addon.addonPath.string();
-//	object["path"] = path;
-//	json::json_pointer p = json::json_pointer("/folders");
-//	workspace.data[p].emplace_back( object );
+//	alert("VSCodeProject::addAddon() " + addon.name, 35);
 
 	workspace.addPath(addon.addonPath);
 	// examples of how to add entries to json arrays
@@ -118,18 +103,15 @@ void VSCodeProject::addAddon(ofAddon & addon) {
 
 
 bool VSCodeProject::saveProjectFile(){
-	alert("VSCodeProject::saveProjectFile() ");
-	
-	alert("--- VSCodeProject::extSrcPaths() ");
-//	cout << extSrcPaths.size() << endl;
-	for (auto & e : extSrcPaths) {
-		cout << e << endl;
-		workspace.addPath(e);
+//	alert("VSCodeProject::saveProjectFile() ");
+//	alert("--- VSCodeProject::extSrcPaths() ");
+//	for (auto & e : extSrcPaths) {
+//		cout << e << endl;
+//		workspace.addPath(e);
+//
+//	}
+//	alert("--- VSCodeProject::extSrcPaths() ");
 
-	}
-	alert("--- VSCodeProject::extSrcPaths() ");
-
-	
 	workspace.save();
 	cppProperties.save();
 	return true;
@@ -137,14 +119,14 @@ bool VSCodeProject::saveProjectFile(){
 
 
 void VSCodeProject::addSrc(const fs::path & srcName, const fs::path & folder, SrcType type){
-	alert ("addSrc " + srcName.string(), 33);
+//	alert ("addSrc " + srcName.string(), 33);
 }
 
 void VSCodeProject::addInclude(std::string includeName){
-	alert ("addInclude " + includeName, 34);
+//	alert ("addInclude " + includeName, 34);
 	cppProperties.addToArray("/env/PROJECT_EXTRA_INCLUDES", fs::path(includeName));
 }
 
 void VSCodeProject::addLibrary(const LibraryBinary & lib){
-	alert ("addLibrary " + lib.path, 35);
+//	alert ("addLibrary " + lib.path, 35);
 }

--- a/commandLine/src/projects/androidStudioProject.cpp
+++ b/commandLine/src/projects/androidStudioProject.cpp
@@ -4,21 +4,20 @@
 #include "Utils.h"
 #include <regex>
 
-using std::string;
 std::string AndroidStudioProject::LOG_NAME = "AndroidStudioProject";
 
 AndroidStudioProject::AndroidStudioProject(const std::string & target) : baseProject(target) {}
 
 bool AndroidStudioProject::createProjectFile(){
 	// Make sure project name doesn't include "-"
-	std::string packageName = projectName;
+	std::string packageName { projectName };
 	ofStringReplace(packageName, "-", "");
 
 	if (!fs::exists(projectDir)) {
 		fs::create_directory(projectDir);
 	}
 
-	vector <string> fileNames = {
+	std::vector <std::string> fileNames {
 		"build.gradle",
 		"settings.gradle",
 		"AndroidManifest.xml",
@@ -33,7 +32,7 @@ bool AndroidStudioProject::createProjectFile(){
 			fs::path from { templatePath / f };
 			try {
 				fs::copy(from, to);
-			} catch(fs::filesystem_error& e) {
+			} catch(fs::filesystem_error & e) {
 				if (f == "AndroidManifest.xml") {
 					findandreplaceInTexfile(to, "TEMPLATE_PACKAGE_NAME", packageName);
 				} else {
@@ -49,8 +48,9 @@ bool AndroidStudioProject::createProjectFile(){
 	
 	findandreplaceInTexfile( projectDir / "res/values/strings.xml", "TEMPLATE_APP_NAME", projectName);
 
-	fs::path from = projectDir / "srcJava/cc/openframeworks/APP_NAME";
-	fs::path to = projectDir / ("srcJava/cc/openframeworks/"+projectName);
+	fs::path from { projectDir / "srcJava/cc/openframeworks/APP_NAME" };
+	fs::path to { projectDir / ("srcJava/cc/openframeworks/" + projectName) };
+	// TODO: try catch
 	fs::rename ( from, to );
 	findandreplaceInTexfile(to / "OFActivity.java", "TEMPLATE_APP_NAME", projectName);
 

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -184,7 +184,6 @@ bool baseProject::create(const fs::path & path, string templateName){
 		vector < string > fileNames;
 		getFilesRecursively(projectDir / "src", fileNames);
 
-		
 		std::sort (fileNames.begin(), fileNames.end());
 		
 //		for (auto & f : fileNames) {

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PG_VERSION "23"
+#define PG_VERSION "25"
 
 #include "ofAddon.h"
 #include "ofFileUtils.h"

--- a/commandLine/src/projects/qtcreatorproject.cpp
+++ b/commandLine/src/projects/qtcreatorproject.cpp
@@ -16,14 +16,14 @@ bool QtCreatorProject::createProjectFile(){
 	
 	fs::path qbsFile { fs::path { projectName + ".qbs" } };
 	vector < std::pair <fs::path, fs::path > > fromTo {
-		{ "qtcreator.qbs",  qbsFile},
+		{ "qtcreator.qbs", qbsFile },
 		{ "Makefile", "Makefile" },
 		{ "config.make", "config.make" },
 	};
 	
 	for (auto & p : fromTo) {
-		fs::path src = templatePath / p.first;
-		fs::path dst = projectDir / p.second;
+		fs::path src { templatePath / p.first };
+		fs::path dst { projectDir / p.second };
 		try {
 			fs::copy_file(src, dst, fs::copy_options::overwrite_existing);
 		} catch(fs::filesystem_error& e) {
@@ -36,7 +36,7 @@ bool QtCreatorProject::createProjectFile(){
 	findandreplaceInTexfile(qbsFile, "emptyExample", projectName);
 
 	// Calculate OF Root in relation to each project (recursively);
-	auto relRoot = fs::relative((fs::current_path() / getOFRoot()), projectDir);
+	auto relRoot { fs::relative((fs::current_path() / getOFRoot()), projectDir) };
 	if (!fs::equivalent(relRoot, "../../..")) {
 		string root = relRoot.string();
 		for (auto & p : fromTo) {
@@ -46,12 +46,13 @@ bool QtCreatorProject::createProjectFile(){
 	return true;
 }
 
+
 void QtCreatorProject::addSrc(const fs::path & srcFile, const fs::path & folder, baseProject::SrcType type){
 	qbsProjectFiles.insert(srcFile.string());
 }
 
-bool QtCreatorProject::loadProjectFile(){
 
+bool QtCreatorProject::loadProjectFile(){
 	fs::path file { projectDir / (projectName + ".qbs") };
 	if (!fs::exists(file)) {
 		ofLogError(LOG_NAME) << "error loading" << file << "doesn't exist";
@@ -95,6 +96,7 @@ bool QtCreatorProject::loadProjectFile(){
 	}
 	return ret;
 }
+
 
 bool QtCreatorProject::saveProjectFile(){
 	auto qbsStr = qbs.getText();
@@ -142,6 +144,7 @@ bool QtCreatorProject::saveProjectFile(){
 //	project.writeFromBuffer(qbs);
 	return true;
 }
+
 
 void QtCreatorProject::addAddon(ofAddon & addon){
 	// FIXME: I think this is unneded since this function here is triggered by baseclass::addAddon(string) which already checked if exists.

--- a/commandLine/src/projects/qtcreatorproject.cpp
+++ b/commandLine/src/projects/qtcreatorproject.cpp
@@ -22,12 +22,13 @@ bool QtCreatorProject::createProjectFile(){
 	};
 	
 	for (auto & p : fromTo) {
+		// FIXME: Wrong paths here. there are some more folders like "wizard" / "openFrameworks"
 		fs::path src { templatePath / p.first };
 		fs::path dst { projectDir / p.second };
 		try {
 			fs::copy_file(src, dst, fs::copy_options::overwrite_existing);
 		} catch(fs::filesystem_error& e) {
-			ofLogError(LOG_NAME) << "error copying template file " << p.first << " : " << p.second << e.what();
+			ofLogError(LOG_NAME) << "error copying template file " << src << " : " << dst << " : " << e.what();
 			return false;
 		}
 	}

--- a/commandLine/src/projects/visualStudioProject.cpp
+++ b/commandLine/src/projects/visualStudioProject.cpp
@@ -11,9 +11,9 @@ bool visualStudioProject::createProjectFile(){
 //	alert("visualStudioProject::createProjectFile");
 
 	solution	= projectDir / (projectName + ".sln");
-	fs::path project 	= projectDir / (projectName + ".vcxproj");
-	fs::path user 		= projectDir / (projectName + ".vcxproj.user");
-	fs::path filters	= projectDir / (projectName + ".vcxproj.filters");
+	fs::path project 	{ projectDir / (projectName + ".vcxproj") };
+	fs::path user 		{ projectDir / (projectName + ".vcxproj.user") };
+	fs::path filters	{ projectDir / (projectName + ".vcxproj.filters") };
 
 	fs::copy(templatePath / "emptyExample.vcxproj", 		project, fs::copy_options::overwrite_existing);
 	fs::copy(templatePath / "emptyExample.vcxproj.user", 	user, fs::copy_options::overwrite_existing);
@@ -35,8 +35,8 @@ bool visualStudioProject::createProjectFile(){
 
 
 	if (!fs::equivalent(getOFRoot(), fs::path{ "../../.." })) {
-		string root = getOFRoot().string() ;
-		string relRootWindows = convertStringToWindowsSeparator(root) + "\\";
+		string root { getOFRoot().string() };
+		string relRootWindows { convertStringToWindowsSeparator(root) + "\\" };
 
 		// sln has windows paths:
 //		alert ("replacing root with " + relRootWindows, 36);
@@ -59,8 +59,8 @@ bool visualStudioProject::loadProjectFile(){
 		ofLogError(LOG_NAME) << "error loading " << projectPath << " doesn't exist";
 		return false;
 	}
-	pugi::xml_parse_result result = doc.load_file(projectPath.c_str());
-	bLoaded = result.status==pugi::status_ok;
+	pugi::xml_parse_result result { doc.load_file(projectPath.c_str()) };
+	bLoaded = result.status == pugi::status_ok;
 //	alert ("visualStudioProject::loadProjectFile() " + projectPath.string() + " : " + ofToString(bLoaded));
 	return bLoaded;
 }
@@ -75,10 +75,10 @@ bool visualStudioProject::saveProjectFile(){
 	 add one entry for each additional, fixing slashes, generating new uuid.
 	 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "openframeworksLib", "..\..\..\libs\openFrameworksCompiled\project\vs\openframeworksLib.vcxproj", "{5837595D-ACA9-485C-8E76-729040CE4B0B}"
 	 EndProject
-	*/
+	 */
 	if (!additionalvcxproj.empty()) {
 		string additionalProjects;
-//		string divider = "\r\n";
+		//		string divider = "\r\n";
 		string divider = "\n";
 		for (auto & a : additionalvcxproj) {
 			string name = a.filename().stem().string();
@@ -89,42 +89,42 @@ bool visualStudioProject::saveProjectFile(){
 			"Project(\"{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}\") = \""+name+"\", \""+aString+"\", \"{"+uuid+"}\"" +
 			divider + "EndProject" + divider;
 		}
-//		string findString = "Global" + divider;
+		//		string findString = "Global" + divider;
 		string findString = "Global";
 		
 		additionalProjects += findString ;
 		
 		solution = solution.lexically_normal();
-//		findandreplaceInTexfile(solution, findString, additionalProjects);
-
+		//		findandreplaceInTexfile(solution, findString, additionalProjects);
+		
 		std::ifstream file(solution);
 		std::stringstream buffer;
 		buffer << file.rdbuf();
 		string str = buffer.str();
 		file.close();
-
+		
 		std::size_t pos = str.find(findString);
 		if (pos != std::string::npos) {
 			str.replace(pos, findString.length(), additionalProjects);
 		}
-
+		
 		std::ofstream myfile(solution);
 		myfile << str;
 		myfile.close();
 		
 		
-//		cout << fs::current_path() << endl;
-//		cout << fs::absolute(solution) << endl;
-//		cout << solution.lexically_normal() << endl;
+		//		cout << fs::current_path() << endl;
+		//		cout << fs::absolute(solution) << endl;
+		//		cout << solution.lexically_normal() << endl;
 	}
 	
-
 	
-	auto filters = projectDir / (projectName + ".vcxproj.filters");
-//	alert ("saving filters file : " + filters.string(), 35);
+	
+	auto filters { projectDir / (projectName + ".vcxproj.filters") };
+	//	alert ("saving filters file : " + filters.string(), 35);
 	bool ok1 = filterXmlDoc.save_file(filters.c_str());
-
-	auto vcxFile = projectDir / (projectName + ".vcxproj");
+	
+	auto vcxFile { projectDir / (projectName + ".vcxproj") };
 //	alert ("saving vcxFile file : " + vcxFile.string(), 35);
 	bool ok2 = doc.save_file(vcxFile.c_str());
 	
@@ -134,8 +134,8 @@ bool visualStudioProject::saveProjectFile(){
 
 void visualStudioProject::appendFilter(string folderName){
 	fixSlashOrder(folderName);
-	string uuid = generateUUID(folderName);
-	string tag = "//ItemGroup[Filter]/Filter[@Include=\"" + folderName + "\"]";
+	string uuid { generateUUID(folderName) };
+	string tag { "//ItemGroup[Filter]/Filter[@Include=\"" + folderName + "\"]" };
 	pugi::xpath_node_set set = filterXmlDoc.select_nodes(tag.c_str());
 	if (set.size() > 0){
 	//pugi::xml_node node = set[0].node();

--- a/commandLine/src/utils/Utils.cpp
+++ b/commandLine/src/utils/Utils.cpp
@@ -391,6 +391,8 @@ unique_ptr<baseProject> getTargetProject(const string & targ) {
 		return unique_ptr<AndroidStudioProject>(new AndroidStudioProject(targ));
 	} else if (targ == "vscode") {
 		return unique_ptr<VSCodeProject>(new VSCodeProject(targ));
+	} else if (targ == "qtcreator") {
+			return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
 	} else {
 		return unique_ptr<baseProject>();
 	}

--- a/commandLine/src/utils/Utils.cpp
+++ b/commandLine/src/utils/Utils.cpp
@@ -375,9 +375,9 @@ unique_ptr<baseProject> getTargetProject(const string & targ) {
 	if (targ == "osx" || targ == "ios") {
 		return unique_ptr<xcodeProject>(new xcodeProject(targ));
 	} else if (targ == "msys2") {
-		return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+//		return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+		return unique_ptr<VSCodeProject>(new VSCodeProject(targ));
 	} else if (targ == "winvs") {
-	
 		return unique_ptr<visualStudioProject>(new visualStudioProject(targ));
 	} else if (targ == "linux" ||
 			   targ == "linux64" ||
@@ -385,8 +385,8 @@ unique_ptr<baseProject> getTargetProject(const string & targ) {
 			   targ == "linuxarmv7l" ||
 			   targ == "linuxaarch64"
 			   ) {
-	
-		return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+//		return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));
+		return unique_ptr<VSCodeProject>(new VSCodeProject(targ));
 	} else if (targ == "android") {
 		return unique_ptr<AndroidStudioProject>(new AndroidStudioProject(targ));
 	} else if (targ == "vscode") {

--- a/commandLine/src/utils/Utils.h
+++ b/commandLine/src/utils/Utils.h
@@ -16,7 +16,7 @@ struct LibraryBinary;
 
 static std::map <ofTargetPlatform, std::string> platformsToString {
 	{ OF_TARGET_ANDROID, "android" },
-//	{ OF_TARGET_EMSCRIPTEN, "linux" },
+//	{ OF_TARGET_EMSCRIPTEN, "" },
 	{ OF_TARGET_IOS, "ios" },
 	{ OF_TARGET_LINUX, "linux" },
 	{ OF_TARGET_LINUX64, "linux64" },


### PR DESCRIPTION
projectGenerator version bump
target platform is now at the top of projectGenerator output.
projectGenerator version now goes into Project.code-workspace, it doesn't interfere with template functionality. 