### PR TITLE
copy .so files to the project folder in linux

### DIFF
--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -546,13 +546,16 @@ bool ofAddon::fromFS(const fs::path & path, const string & platform){
 			
 
 		}
-		if(platform == "vs" || platform == "msys2"){
+//		if(platform == "vs" || platform == "msys2"){
+		if(platform == "vs" || platform == "msys2" 
+			   || platform == "vscode"
+			   || platform == "linux"
+			   || platform == "linux64"
+			   || platform == "linuxarmv6l"
+			   || platform == "linuxarmv7l"
+			   || platform == "linuxaarch64"
+		   ){
 			getDllsRecursively(libsPath, dllsToCopy, platform);
-			
-//			alert ("ofAddon dllsToCopy", 32);
-//			for (auto & d : dllsToCopy) {
-//				cout << d << endl;
-//			}
 		}
 	}
 	

--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -95,6 +95,7 @@ void VSCodeProject::addAddon(ofAddon & addon) {
 //	alert("VSCodeProject::addAddon() " + addon.name, 35);
 
 	workspace.addPath(addon.addonPath);
+	
 	// examples of how to add entries to json arrays
 //	cppProperties.addToArray("/env/PROJECT_ADDON_INCLUDES", addon.addonPath);
 //	cppProperties.addToArray("/env/PROJECT_EXTRA_INCLUDES", addon.addonPath);

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -358,7 +358,30 @@ void baseProject::addAddon(string addonName){
 		addInclude(e);
 	}
 	
-	
+	// It was part exclusive of visualStudioProject. now it is part of baseProject, so dlls are copied in VSCode project and .so files in linux
+	for (auto & d : addon.dllsToCopy) {
+		ofLogVerbose() << "adding addon dlls to bin: " << d;
+		fs::path from { d };
+		fs::path to { projectDir / "bin" / from.filename() };
+		if (from.extension() == ".so") {
+			fs::path folder { projectDir / "bin" / "libs" };
+			if (!fs::exists(folder)) {
+				try {
+					fs::create_directory(folder);
+				} catch(fs::filesystem_error& e) {
+					ofLogError("baseProject::addAddon") << "error creating folder " << folder << e.what();
+				}
+			}
+//			to = projectDir / "bin" / "libs" / from.filename();
+			to = folder / from.filename();
+		}
+		
+		try {
+			fs::copy_file(from, to, fs::copy_options::overwrite_existing);
+		} catch(fs::filesystem_error& e) {
+			ofLogError("baseProject::addAddon") << "error copying template file " << from << endl << "to: " << to << endl <<  e.what();
+		}
+	}
 	
 	// MARK: - SPECIFIC for each project.
 	// XCode and VS override the base addAddon. other templates will use baseproject::addAddon(ofAddon...

--- a/commandLine/src/projects/visualStudioProject.cpp
+++ b/commandLine/src/projects/visualStudioProject.cpp
@@ -531,26 +531,6 @@ void visualStudioProject::addAddon(ofAddon & addon) {
 //		addSrc(addon.headersrcFiles[i],addon.filesToFolders[addon.headersrcFiles[i]],C);
 
 
-	for (auto & d : addon.dllsToCopy) {
-		ofLogVerbose() << "adding addon dlls to bin: " << d;
-//		fs::path from = addon.addonPath / d;
-		fs::path from { d };
-		fs::path to { projectDir / "bin" / from.filename() };
-		
-//		alert("copy from to " + from.string() + " : " + to.string(), 35);
-//		alert("addonPath " + addon.addonPath.string(), 36);
-//		alert("d " + d, 36);
-//		alert("copy from " + from.string(), 35);
-//		alert("copy to " + to.string(), 35);
-
-		
-		try {
-			fs::copy_file(from, to, fs::copy_options::overwrite_existing);
-		} catch(fs::filesystem_error& e) {
-			ofLogError(LOG_NAME) << "error copying template file " << from << endl << "to: " << to << endl <<  e.what();
-		}
-	}
-
 	
 
 	for (auto & a : addon.cflags) {

--- a/commandLine/src/utils/Utils.cpp
+++ b/commandLine/src/utils/Utils.cpp
@@ -238,7 +238,7 @@ void getDllsRecursively(const fs::path & path, std::vector < string > & dlls, st
 	if (!fs::exists(path) || !fs::is_directory(path)) return;
 
 	for (const auto & f : dirList(path)) {
-		if (fs::is_regular_file(f) && f.extension() == ".dll") {
+		if (fs::is_regular_file(f) && (f.extension() == ".dll" || f.extension() == ".so")) {
 			dlls.emplace_back(f.string());
 		}
 	}


### PR DESCRIPTION
this PR tries to address this issue https://github.com/openframeworks/projectGenerator/issues/420

I've expanded the usage of getDllsRecursively to get .so files also, and moved parsing ```addon.dllsToCopy``` from exclusive template visualStudioProject to the baseProject.
it means it will try to copy .dll and .so files to the respective folders inside the project (different folders for each file extension) in different templates.

it needs testing.
if it goes well I can rename function getDllsRecursively to getLibrariesRecursively or similar.