### PR TITLE
VSCode fix

### DIFF
--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -73,7 +73,7 @@ bool VSCodeProject::createProjectFile(){
 		return false;
 	}
 
-	
+
 	auto templateConfig { projectDir / "template.config" };
 	try {
 		fs::remove( templateConfig );
@@ -81,7 +81,7 @@ bool VSCodeProject::createProjectFile(){
 		ofLogError(LOG_NAME) << "error removing file " << " : " << templateConfig << " : " << e.what();
 	}
 
-	
+
 	// Rename Project Workspace
 	try {
 		fs::rename(projectDir / "emptyExample.code-workspace", workspace.fileName);

--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -67,6 +67,8 @@ bool VSCodeProject::createProjectFile(){
 	
 	// Copy all files from template, recursively
 	try {
+//		alert ("copy from " + templatePath.string());
+//		alert ("copy to " + projectDir.string());
 		fs::copy(templatePath, projectDir, fs::copy_options::overwrite_existing | fs::copy_options::recursive);
 	} catch(fs::filesystem_error& e) {
 		ofLogError(LOG_NAME) << "error copying folder " << templatePath << " : " << projectDir << " : " << e.what();
@@ -84,6 +86,11 @@ bool VSCodeProject::createProjectFile(){
 	
 	// Rename Project Workspace
 	try {
+		
+		if (fs::exists(workspace.fileName)) {
+			
+		}
+		
 		fs::rename(projectDir / "emptyExample.code-workspace", workspace.fileName);
 	} catch(fs::filesystem_error& e) {
 		ofLogError(LOG_NAME) << "error renaming folder " << " : " << workspace.fileName << " : " << e.what();

--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -67,15 +67,13 @@ bool VSCodeProject::createProjectFile(){
 	
 	// Copy all files from template, recursively
 	try {
-//		alert ("copy from " + templatePath.string());
-//		alert ("copy to " + projectDir.string());
 		fs::copy(templatePath, projectDir, fs::copy_options::overwrite_existing | fs::copy_options::recursive);
 	} catch(fs::filesystem_error& e) {
 		ofLogError(LOG_NAME) << "error copying folder " << templatePath << " : " << projectDir << " : " << e.what();
 		return false;
 	}
 
-
+	
 	auto templateConfig { projectDir / "template.config" };
 	try {
 		fs::remove( templateConfig );

--- a/commandLine/src/projects/VSCodeProject.cpp
+++ b/commandLine/src/projects/VSCodeProject.cpp
@@ -86,14 +86,9 @@ bool VSCodeProject::createProjectFile(){
 	
 	// Rename Project Workspace
 	try {
-		
-		if (fs::exists(workspace.fileName)) {
-			
-		}
-		
 		fs::rename(projectDir / "emptyExample.code-workspace", workspace.fileName);
 	} catch(fs::filesystem_error& e) {
-		ofLogError(LOG_NAME) << "error renaming folder " << " : " << workspace.fileName << " : " << e.what();
+		ofLogError(LOG_NAME) << "error renaming project " << " : " << workspace.fileName << " : " << e.what();
 		return false;
 	}
 	return true;

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -24,7 +24,17 @@ baseProject::baseProject(const string & _target) : target(_target) {
 }
 
 fs::path baseProject::getPlatformTemplateDir() {
-	return getOFRoot() / templatesFolder / target;
+	string folder { target };
+	if ( target == "msys2"
+		|| target == "linux"
+		|| target == "linux64"
+		|| target == "linuxarmv6l"
+		|| target == "linuxarmv7l"
+		|| target == "linuxaarch64"
+	) {
+		folder = "vscode";
+	}
+	return getOFRoot() / templatesFolder / folder;
 }
 
 

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PG_VERSION "26"
+#define PG_VERSION "27"
 
 #include "ofAddon.h"
 #include "ofFileUtils.h"


### PR DESCRIPTION
different platforms called point to the same vscode folder now.

One thing to consider here:

Are all config.make and Makefiles equal? 
I've noticed msys2 folder has different entries 
I think there is some entries related to windows icon 
maybe we can copy config.make from msys2 to vscode folder.