### PR TITLE
macOS: updates to version and custom app icon handling

### DIFF
--- a/commandLine/Project.xcconfig
+++ b/commandLine/Project.xcconfig
@@ -18,16 +18,16 @@ DEVELOPMENT_LANGUAGE = English
 CODE_SIGN_IDENTITY = -
 INFOPLIST_FILE = openFrameworks-Info.plist
 
-// VERSIONING - uncomment to override settings in Xcode UI
+// VERSIONING - overridden if changed in Xcode UI
 
 // this is "Version" in the Xcode target Identity UI
 // suggested to use semantic versioning format ala #.#.#
-//MARKETING_VERSION = 0.1.0
+MARKETING_VERSION = 0.1.0
 
 // this is "Build" in the Xcode target Identity UI, an incremental build number
 // important for the App Store as new build submissions need a diff number even
 // if MARKETING_VERSION is the same
-//CURRENT_PRODUCT_VERSION = 1
+CURRENT_PROJECT_VERSION = 1
 
 // ICONS
 

--- a/commandLine/Project.xcconfig
+++ b/commandLine/Project.xcconfig
@@ -18,23 +18,36 @@ DEVELOPMENT_LANGUAGE = English
 CODE_SIGN_IDENTITY = -
 INFOPLIST_FILE = openFrameworks-Info.plist
 
-// Versioning, uncomment to override settings in Xcode UI
+// VERSIONING - uncomment to override settings in Xcode UI
+
 // this is "Version" in the Xcode target Identity UI
 // suggested to use semantic versioning format ala #.#.#
 //MARKETING_VERSION = 0.1.0
+
 // this is "Build" in the Xcode target Identity UI, an incremental build number
 // important for the App Store as new build submissions need a diff number even
-// if version is the same
+// if MARKETING_VERSION is the same
 //CURRENT_PRODUCT_VERSION = 1
 
-//ICONS - NEW IN 0072 
-//ICON_NAME = icon.icns
-//ICON_NAME[config=Debug] = icon-debug.icns
+// ICONS
+
+// default oF app icon
 ICON_NAME = of.icns
 ICON_NAME[config=Debug] = of_debug.icns
 ICON_FILE = $(OF_PATH)/libs/openFrameworksCompiled/project/osx/$(ICON_NAME)
-//IF YOU WANT AN APP TO HAVE A CUSTOM ICON - PUT THEM IN YOUR DATA FOLDER AND CHANGE ICON_FILE_PATH to:
-//ICON_FILE_PATH = bin/data/
+
+// custom app icon, placed in main project folder
+//ICON_NAME = MyApp.icns
+//ICON_FILE = $(ICON_NAME)
+
+// custom app icon with separate Release and Debug versions placed in bin/data
+//ICON_NAME = icon.icns
+//ICON_NAME[config=Debug] = icon-debug.icns
+//ICON_FILE = bin/data/$(ICON_NAME)
+
+// note: oF 0.7.2 - 0.11 used ICON_FILE_PATH which is no longer used in oF 0.12+
+// ex. change ICON_FILE_PATH = bin/data/ -> ICON_FILE = bin/data/$(ICON_NAME) &
+// in a custom openFrameworks-Info.plist, set CFBundleIconFile to ICON_NAME
 
 //FOR AV ENGINE SOUND PLAYER UNCOMMENT TWO LINES BELOW
 //OF_NO_FMOD=1

--- a/commandLine/Project.xcconfig
+++ b/commandLine/Project.xcconfig
@@ -14,10 +14,18 @@ PRODUCT_NAME = $(TARGET_NAME)
 PRODUCT_NAME[config=Debug] = $(TARGET_NAME)Debug
 PRODUCT_BUNDLE_IDENTIFIER = cc.openFrameworks.$(TARGET_NAME)
 //PRODUCT_BUNDLE_IDENTIFIER[config=Debug] = cc.openFrameworks.$(TARGET_NAME)Debug
-VERSION = 1.0
 DEVELOPMENT_LANGUAGE = English
 CODE_SIGN_IDENTITY = -
 INFOPLIST_FILE = openFrameworks-Info.plist
+
+// Versioning, uncomment to override settings in Xcode UI
+// this is "Version" in the Xcode target Identity UI
+// suggested to use semantic versioning format ala #.#.#
+//MARKETING_VERSION = 0.1.0
+// this is "Build" in the Xcode target Identity UI, an incremental build number
+// important for the App Store as new build submissions need a diff number even
+// if version is the same
+//CURRENT_PRODUCT_VERSION = 1
 
 //ICONS - NEW IN 0072 
 //ICON_NAME = icon.icns

--- a/commandLine/openFrameworks-Info.plist
+++ b/commandLine/openFrameworks-Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PRODUCT_VERSION)</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.graphics-design</string>
 	<key>NSCameraUsageDescription</key>

--- a/commandLine/openFrameworks-Info.plist
+++ b/commandLine/openFrameworks-Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(VERSION)</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>$(VERSION)</string>
+	<string>$(CURRENT_PRODUCT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.graphics-design</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
This PR implements changes proposed in #429 and #430:

* separate Project.xcconfig `VERSION` into the default `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` variables to match Xcode UI
* add examples to new method for setting custom app icons as well as info in transitioning from previous `ICON_FILE_PATH` variable