### PR TITLE
CI macOS PG Ci Test

### DIFF
--- a/scripts/osx/ci_build_pg.sh
+++ b/scripts/osx/ci_build_pg.sh
@@ -74,9 +74,9 @@ package_app(){
 		# need to upload zip of just app to apple for notarizing
 		zip --symlinks -r -q projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip projectGenerator-$PLATFORM/projectGenerator.app
 		xcrun altool --notarize-app --primary-bundle-id "com.electron.projectgenerator" --username "${GA_APPLE_USERNAME}" -p "${GA_APPLE_PASS}" --asc-provider "${GA_NOTARIZE_PROVIDER}" --file projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip
-		mv projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip ${PG_DIR}/../../../projectGenerator-$PLATFORM.zip
-		cd ${PG_DIR}/../../../
-		echo "Final Directory contents: ${PG_DIR}/../../../"
+		mv projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip ${PG_DIR}/../../../projectGenerator/projectGenerator-$PLATFORM.zip
+		cd ${PG_DIR}/../../../projectGenerator
+		echo "Final Directory contents: ${PG_DIR}/../../../projectGenerator"
 		pwd
 		ls
 		echo "-------------"
@@ -206,16 +206,6 @@ mv frontend/dist/mac-universal ${PG_DIR}/projectGenerator-osx
 echo "-------------"
 echo "package_app osx"
 package_app osx
-
-
-cd ${PG_DIR}/projectGenerator-osx
-
-echo "Current directory: (should be ${PG_DIR}/projectGenerator-osx"
-pwd
-echo "Directory contents:"
-ls
-echo "-------------"
-
 
 # echo "package_app ios"
 # npm run build:macos > /dev/null


### PR DESCRIPTION
- Final output cache is removed unless in core directory... 
- Set final zip output to within projectGenerator (core runner dir) else cache is removed and zip fails to upload. 