### PR TITLE
osx to macos

### DIFF
--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -53,7 +53,7 @@ bool ofAddon::checkCorrectVariable(const string & variable, const string & state
 						 AddonMetaVariables.end(),
 						 variable) != AddonMetaVariables.end();
 	}
-	else if (state == "osx") {
+	else if (state == "macos") {
 		return std::find(AddonProjectVariables.begin(),
 						 AddonProjectVariables.end(),
 						 variable) != AddonProjectVariables.end();
@@ -470,7 +470,7 @@ void ofAddon::parseLibsPath(const fs::path & libsPath, const fs::path & parentFo
 	
 
 	getLibsRecursively(libsPath, libFiles, libs, platform);
-	if (platform == "osx" || platform == "ios"){
+	if (platform == "macos" || platform == "ios"){
 		getFrameworksRecursively(libsPath, frameworks, platform);
 		getXCFrameworksRecursively(libsPath, frameworks, platform);
 	}

--- a/commandLine/src/addons/ofAddon.h
+++ b/commandLine/src/addons/ofAddon.h
@@ -42,7 +42,7 @@ const vector<string> parseStates {
 	"android/x86_64",
 	"emscripten",
 	"ios",
-	"osx",
+	"macos",
 	"tvos",
 	"watchos",
 	"visionos",
@@ -127,27 +127,27 @@ public:
 	std::unordered_map < string, string > filesToFolders;      //the addons has had, for each file,
 												//sometimes a listing of what folder to put it in, such as "addons/ofxOsc/src"
 
-	vector < string > srcFiles;
-	vector < string > csrcFiles;
-	vector < string > cppsrcFiles;
-	vector < string > headersrcFiles;
-	vector < string > objcsrcFiles;
-//	vector < string > propsFiles;
-	vector < fs::path > propsFiles;
-	vector < LibraryBinary > libs;
-	vector < string > dllsToCopy;
-	vector < string > includePaths;
+	vector <string> srcFiles;
+	vector <string> csrcFiles;
+	vector <string> cppsrcFiles;
+	vector <string> headersrcFiles;
+	vector <string> objcsrcFiles;
+//	vector <string> propsFiles;
+	vector <fs::path> propsFiles;
+	vector <LibraryBinary> libs;
+	vector <string> dllsToCopy;
+	vector <string> includePaths;
 
 	// From addon_config.mk
-	vector < string > dependencies;
-	vector < string > cflags;   // C_FLAGS
-	vector < string > cppflags; // CXX_FLAGS
-	vector < string > ldflags;
-	vector < string > pkgConfigLibs; 	// linux only
-	vector < string > frameworks;		// osx only
-	vector <string >  xcframeworks; // osx only
-	vector < string > data;
-	vector < string > defines;
+	vector <string> dependencies;
+	vector <string> cflags;   // C_FLAGS
+	vector <string> cppflags; // CXX_FLAGS
+	vector <string> ldflags;
+	vector <string> pkgConfigLibs; 	// linux only
+	vector <string> frameworks;		// macos only
+	vector <string> xcframeworks; 	// macos only
+	vector <string> data;
+	vector <string> defines;
 
 	// metadata
 	string name;

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -15,7 +15,7 @@ constexpr option::Descriptor usage[] =
 	{HELP, 0,"h", "help",option::Arg::None, "  --help  \tPrint usage and exit." },
 	{RECURSIVE, 0,"r","recursive",option::Arg::None, "  --recursive, -r  \tupdate recursively (applies only to update)" },
 	{LISTTEMPLATES, 0,"l","listtemplates",option::Arg::None, "  --listtemplates, -l  \tlist templates available for the specified or current platform(s)" },
-	{PLATFORMS, 0,"p","platforms",option::Arg::Optional, "  --platforms, -p  \tplatform list (such as osx, ios, winvs)" },
+	{PLATFORMS, 0,"p","platforms",option::Arg::Optional, "  --platforms, -p  \tplatform list (such as macos, ios, winvs)" },
 	{ADDONS, 0,"a","addons",option::Arg::Optional, "  --addons, -a  \taddon list (such as ofxOpenCv, ofxGui, ofxXmlSettings)" },
 	{OFPATH, 0,"o","ofPath",option::Arg::Optional, "  --ofPath, -o  \tpath to openframeworks (relative or absolute). This *must* be set, or you can also alternatively use an environment variable PG_OF_PATH and if this isn't set, it will use that value instead" },
 	{VERBOSE, 0,"v","verbose",option::Arg::None, "  --verbose, -v  \trun verbose" },

--- a/commandLine/src/main.cpp
+++ b/commandLine/src/main.cpp
@@ -131,6 +131,10 @@ void addPlatforms(const string & value) {
 				targets.emplace_back(option);
 			}
 		} else {
+			// It can be removed later when PG frontend is updated
+			if (p == "osx") {
+				p = "macos";
+			}
 			targets.emplace_back(p);
 		}
 	}

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -621,7 +621,7 @@ void baseProject::parseConfigMake(){
 			if(varValue.size()>1){
 				auto var = ofTrim(varValue[0]);
 				auto value = ofTrim(varValue[1]);
-				if (var=="PROJECT_AFTER_OSX" && target=="osx"){
+				if (var=="PROJECT_AFTER_OSX" && target=="macos"){
 					addAfterRule(value);
 				}
 			}

--- a/commandLine/src/projects/baseProject.cpp
+++ b/commandLine/src/projects/baseProject.cpp
@@ -139,6 +139,12 @@ bool baseProject::create(const fs::path & path, string templateName){
 	extSrcPaths.clear();
 
 	templatePath = getPlatformTemplateDir();
+	if (!fs::exists(templatePath)) {
+		ofLogError() << "templatePath not found " << templatePath << endl;
+		std::exit(0);
+		return false;
+	}
+	
 	projectDir = path;
 	auto projectPath = fs::canonical(fs::current_path() / path);
 	projectName = projectPath.filename().string();

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PG_VERSION "33"
+#define PG_VERSION "34"
 
 #include "ofAddon.h"
 #include "ofFileUtils.h"

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -8,7 +8,7 @@ using nlohmann::json_pointer;
 
 xcodeProject::xcodeProject(const string & target) : baseProject(target){
 	// TODO: remove unused variables
-	if( target == "osx" ){
+	if( target == "macos" ){
 		folderUUID = {
 			{ "src", 			"E4B69E1C0A3A1BDC003C02F2" },
 			{ "addons", 		"BB4B014C10F69532006C3DED" },
@@ -102,12 +102,13 @@ bool xcodeProject::createProjectFile(){
 		}
 	}
 
-	if( target == "osx" ){
+	if( target == "macos" ){
 		// TODO: TEST
 		for (auto & f : { "openFrameworks-Info.plist", "of.entitlements" }) {
 			fs::copy(templatePath / f, projectDir / f, fs::copy_options::overwrite_existing);
 		}
-	}else{
+	} else {
+		// ios
 		for (auto & f : { "ofxiOS-Info.plist", "ofxiOS_Prefix.pch" }) {
 			fs::copy(templatePath / f, projectDir / f, fs::copy_options::overwrite_existing);
 		}
@@ -121,7 +122,7 @@ bool xcodeProject::createProjectFile(){
 
 	saveScheme();
 
-	if(target=="osx"){
+	if(target == "macos"){
 		saveMakefile();
 	}
 
@@ -159,7 +160,7 @@ bool xcodeProject::createProjectFile(){
 //		alert ("fs not equivalent to ../../.. root = " + root);
 		findandreplaceInTexfile(projectDir / (projectName + ".xcodeproj/project.pbxproj"), "../../..", root);
 		findandreplaceInTexfile(projectDir / "Project.xcconfig", "../../..", root);
-		if( target == "osx" ){
+		if (target == "macos") {
 			findandreplaceInTexfile(projectDir / "Makefile", "../../..", root);
 			// MARK: not needed because baseProject::save() does the same
 //			findandreplaceInTexfile(projectDir / "config.make", "../../..", root);
@@ -179,7 +180,7 @@ void xcodeProject::saveScheme(){
 	}
 	fs::create_directories(schemeFolder);
 
-	if(target=="osx"){
+	if(target=="macos"){
 		for (auto & f : { string("Release"), string("Debug") }) {
 			auto fileFrom = templatePath / ("emptyExample.xcodeproj/xcshareddata/xcschemes/emptyExample " + f + ".xcscheme");
 			auto fileTo = schemeFolder / (projectName + " " +f+ ".xcscheme");
@@ -223,8 +224,8 @@ void xcodeProject::renameProject(){ //base
 	// FIXME: review BUILT_PRODUCTS_DIR
 	commands.emplace_back("Set :objects:"+buildConfigurationListUUID+":name " + projectName);
 
-	// Just OSX here, debug app naming.
-	if( target == "osx" ){
+	// Just macos here, debug app naming.
+	if( target == "macos" ){
 		// TODO: Hardcode to variable
 		// FIXME: Debug needed in name?
 		commands.emplace_back("Set :objects:E4B69B5B0A3A1756003C02F2:path " + projectName + "Debug.app");
@@ -384,7 +385,7 @@ void xcodeProject::addSrc(const fs::path & srcFile, const fs::path & folder, Src
 			fileKind = "sourcecode.cpp.objcpp";
 			break;
 		default:
-			ofLogError() << "explicit source type " << type << " not supported yet on osx for " << srcFile;
+			ofLogError() << "explicit source type " << type << " not supported yet on macos for " << srcFile;
 			break;
 		}
 	}

--- a/commandLine/src/projects/xcodeProject.h
+++ b/commandLine/src/projects/xcodeProject.h
@@ -55,8 +55,8 @@ public:
 		"E4B69B600A3A1757003C02F2", //macOS Debug
 		"E4B69B610A3A1757003C02F2", //macOS Release
 
-		"E4B69B4E0A3A1720003C02F2", //macOS Debug SDKROOT macosx
-		"E4B69B4F0A3A1720003C02F2", //macOS Release SDKROOT macosx
+		"E4B69B4E0A3A1720003C02F2", //macOS Debug SDKROOT macos
+		"E4B69B4F0A3A1720003C02F2", //macOS Release SDKROOT macos
 	};
 
 	string buildConfigs[2] = {

--- a/commandLine/src/utils/Utils.cpp
+++ b/commandLine/src/utils/Utils.cpp
@@ -159,7 +159,7 @@ static std::vector <string> platforms;
 bool isFolderNotCurrentPlatform(const string & folderName, const string & platform){
 	if( platforms.size() == 0 ){
 		platforms = {
-			"osx",
+			"macos",
 			"msys2",
 			"vs",
 			"ios",
@@ -290,7 +290,7 @@ void getLibsRecursively(const fs::path & path, std::vector < fs::path > & libFil
 		auto f = it->path();
 
 		if (fs::is_directory(f)) {
-			// on osx, framework is a directory, let's not parse it....
+			// on macos, framework is a directory, let's not parse it....
 			if ((f.extension() == ".framework") || (f.extension() == ".xcframework")) {
 				it.disable_recursion_pending();
 				continue;
@@ -328,11 +328,11 @@ void getLibsRecursively(const fs::path & path, std::vector < fs::path > & libFil
 					libLibs.push_back({ f.string(), arch, target });
 
 					//TODO: THEO hack
-					if( platform == "ios" ){ //this is so we can add the osx libs for the simulator builds
+					if( platform == "ios" ){ //this is so we can add the macos libs for the simulator builds
 						string currentPath = f.string();
 						//TODO: THEO double hack this is why we need install.xml - custom ignore ofxOpenCv
 						if( currentPath.find("ofxOpenCv") == string::npos ){
-							ofStringReplace(currentPath, "ios", "osx");
+							ofStringReplace(currentPath, "ios", "macos");
 							if( fs::exists(currentPath) ){
 								libLibs.push_back({ currentPath, arch, target });
 							}
@@ -407,7 +407,7 @@ unique_ptr<baseProject> getTargetProject(const string & targ) {
 //	cout << "getTargetProject :" << getTargetString(targ) << endl;
 //	typedef xcodeProject pgProject;
 
-	if (targ == "osx" || targ == "ios") {
+	if (targ == "macos" || targ == "ios") {
 		return unique_ptr<xcodeProject>(new xcodeProject(targ));
 	} else if (targ == "msys2") {
 //		return unique_ptr<QtCreatorProject>(new QtCreatorProject(targ));

--- a/commandLine/src/utils/Utils.h
+++ b/commandLine/src/utils/Utils.h
@@ -24,7 +24,7 @@ static std::map <ofTargetPlatform, std::string> platformsToString {
 	{ OF_TARGET_LINUXARMV7L, "linuxarmv7l" },
 	{ OF_TARGET_LINUXAARCH64, "linuxaarch64" },
 	{ OF_TARGET_MINGW, "msys2" },
-	{ OF_TARGET_OSX, "osx" },
+	{ OF_TARGET_OSX, "macos" },
 	{ OF_TARGET_WINVS, "vs" },
 };
 
@@ -38,7 +38,7 @@ static std::vector < std::string > platformsOptions {
 	"linuxarmv7l",
 	"linuxaarch64",
 	"msys2",
-	"osx",
+	"macos",
 	"vs",
 };
 


### PR DESCRIPTION
This one renames osx to macos on project generator commandline.
it will require a folder rename in OF project, 
```../../../scripts/templates/osx ```
to
```../../../scripts/templates/macos```

projectGenerator Frontend can be udpated later, as parameter "osx" will be converted to "macos" internally for now