### PR TITLE
Better templates file handling (copying, renaming, replacing content)

### DIFF
--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -5,8 +5,9 @@
 #include "ofAddon.h"
 #include "ofFileUtils.h"
 #include "pugixml.hpp"
-
 #include <map>
+
+
 namespace fs = of::filesystem;
 
 class baseProject {
@@ -79,6 +80,9 @@ public:
 	bool bMakeRelative = false;
 
 
+
+
+
 	// this shouldn't be called by anyone.  call "create(...), save" etc
 private:
 
@@ -100,4 +104,73 @@ protected:
 	//cached addons - if an addon is requested more than once, avoid loading from disk as it's quite slow
 	std::unordered_map<std::string,std::unordered_map<std::string, ofAddon>> addonsCache; //indexed by [platform][supplied path]
 	bool isAddonInCache(const std::string & addonPath, const std::string platform); //is this addon in the mem cache?
+	
+	static void replaceAll(std::string& str, const std::string& from, const std::string& to) {
+		if(from.empty())
+			return;
+		size_t start_pos = 0;
+		while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+			str.replace(start_pos, from.length(), to);
+			start_pos += to.length(); // In case 'to' contains 'from', like replacing 'x' with 'yx'
+		}
+	}
+
+	struct copyTemplateFile {
+	public:
+		fs::path from;
+		fs::path to;
+		std::vector <std::pair <string, string> > findReplaces;
+		
+		bool run() {
+			// needed for mingw only. maybe a ifdef here.
+			if (fs::exists(from)) {
+				if (fs::exists(to)) {
+					fs::remove(to);
+				}
+
+				if (findReplaces.size()) {
+					// Load file, replace contents, write to destination.
+					
+					std::ifstream fileFrom(from);
+					std::string contents((std::istreambuf_iterator<char>(fileFrom)), std::istreambuf_iterator<char>());
+					fileFrom.close();
+
+					for (auto & f : findReplaces) {
+						replaceAll(contents, f.first, f.second);
+					}
+					
+					std::ofstream fileTo(to);
+					try{
+						fileTo << contents;
+					}catch(std::exception & e){
+						std::cout << "Error saving to " << to << " : " << e.what() << std::endl;
+						return false;
+					}catch(...){
+						std::cout << "Error saving to " << to << std::endl;
+						return false;
+					}
+					
+				} else {
+					// straight copy
+					try {
+						fs::copy(from, to, fs::copy_options::overwrite_existing);
+					}
+					catch(fs::filesystem_error & e) {
+						std::cout << "error copying template file " << from << " : " << to << std::endl;
+						std::cout << e.what() << std::endl;
+						return false;
+					}
+				}
+				
+				std::cout << "exists! " << from << std::endl;
+			} else {
+				return false;
+			}
+
+			return true;
+			std::cout << "----" << std::endl;
+		}
+	};
+
+	vector <copyTemplateFile> copyTemplateFiles;
 };

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -124,9 +124,11 @@ protected:
 		bool run() {
 			// needed for mingw only. maybe a ifdef here.
 			if (fs::exists(from)) {
+#if defined(__MINGW32__) || defined(__MINGW64__)
 				if (fs::exists(to)) {
 					fs::remove(to);
 				}
+#endif
 
 				if (findReplaces.size()) {
 					// Load file, replace contents, write to destination.

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -163,14 +163,12 @@ protected:
 						return false;
 					}
 				}
-				
-				std::cout << "exists! " << from << std::endl;
 			} else {
 				return false;
 			}
 
 			return true;
-			std::cout << "----" << std::endl;
+//			std::cout << "----" << std::endl;
 		}
 	};
 

--- a/commandLine/src/projects/visualStudioProject.cpp
+++ b/commandLine/src/projects/visualStudioProject.cpp
@@ -9,17 +9,77 @@ bool visualStudioProject::createProjectFile(){
 
 	ensureDllDirectoriesExist();
 
-	solution	= projectDir / (projectName + ".sln");
-	fs::path project 	{ projectDir / (projectName + ".vcxproj") };
-	fs::path user 		{ projectDir / (projectName + ".vcxproj.user") };
-	fs::path filters	{ projectDir / (projectName + ".vcxproj.filters") };
+	solution = projectDir / (projectName + ".sln");
 
-	fs::copy(templatePath / "emptyExample.vcxproj", 		project, fs::copy_options::overwrite_existing);
-	fs::copy(templatePath / "emptyExample.vcxproj.user", 	user, fs::copy_options::overwrite_existing);
-	fs::copy(templatePath / "emptyExample.sln", 			solution, fs::copy_options::overwrite_existing);
-	fs::copy(templatePath / "emptyExample.vcxproj.filters", filters, fs::copy_options::overwrite_existing);
+//	findandreplaceInTexfile(solution, "emptyExample", projectName);
+//	findandreplaceInTexfile(user, "emptyExample", projectName);
+//	findandreplaceInTexfile(project, "emptyExample", projectName);
+	
+	std::pair <string, string> replacements;
+	if (!fs::equivalent(getOFRoot(), fs::path{ "../../.." })) {
+		string root { getOFRoot().string() };
+		string relRootWindows { convertStringToWindowsSeparator(root) + "\\" };
+		replacements = { "..\\..\\..\\", relRootWindows };
+	} else {
+//		cout << "equivalent to default ../../.." << endl;
+	}
+	
+	// solution
+	copyTemplateFiles.push_back({
+		templatePath / "emptyExample.sln",
+		projectDir / (projectName + ".sln"),
+		{
+			{ "emptyExample", projectName },
+			replacements
+		}
+	});
+	// project
+	copyTemplateFiles.push_back({
+		templatePath / "emptyExample.vcxproj",
+		projectDir / (projectName + ".vcxproj"),
+		{
+			{ "emptyExample", projectName },
+			replacements
+		}
 
-	fs::copy(templatePath / "icon.rc", projectDir / "icon.rc", fs::copy_options::overwrite_existing);
+	});
+	// user
+	copyTemplateFiles.push_back({
+		templatePath / "emptyExample.vcxproj.user",
+		projectDir / (projectName + ".vcxproj"),
+		{{ "emptyExample", projectName }}
+
+	});
+
+	// filters
+	copyTemplateFiles.push_back({
+		templatePath / "emptyExample.vcxproj.filters",
+		projectDir / (projectName + ".vcxproj.filters")
+	});
+
+	// icon
+	copyTemplateFiles.push_back({
+		templatePath / "icon.rc",
+		projectDir / "icon.rc"
+	});
+
+	for (auto & c : copyTemplateFiles) {
+		c.run();
+	}
+
+	// fs::path project 	{ projectDir / (projectName + ".vcxproj") };
+	// fs::path user 		{ projectDir / (projectName + ".vcxproj.user") };
+	// fs::path filters	{ projectDir / (projectName + ".vcxproj.filters") };
+
+	// fs::copy(templatePath / "emptyExample.vcxproj", 		project, fs::copy_options::overwrite_existing);
+	// fs::copy(templatePath / "emptyExample.vcxproj.user", 	user, fs::copy_options::overwrite_existing);
+	// fs::copy(templatePath / "emptyExample.sln", 			solution, fs::copy_options::overwrite_existing);
+	// fs::copy(templatePath / "emptyExample.vcxproj.filters", filters, fs::copy_options::overwrite_existing);
+	// fs::copy(templatePath / "icon.rc", projectDir / "icon.rc", fs::copy_options::overwrite_existing);
+
+	// after copy, after all execution
+
+	 fs::path filters { projectDir / (projectName + ".vcxproj.filters") };
 
 	pugi::xml_parse_result result = filterXmlDoc.load_file(filters.c_str());
 	if (result.status==pugi::status_ok) {
@@ -28,25 +88,25 @@ bool visualStudioProject::createProjectFile(){
 		ofLogVerbose() << "problem loading filter ";
 	}
 
-	findandreplaceInTexfile(solution, "emptyExample", projectName);
-	findandreplaceInTexfile(user, "emptyExample", projectName);
-	findandreplaceInTexfile(project, "emptyExample", projectName);
+	// findandreplaceInTexfile(solution, "emptyExample", projectName);
+	// findandreplaceInTexfile(user, "emptyExample", projectName);
+	// findandreplaceInTexfile(project, "emptyExample", projectName);
 
 
-	if (!fs::equivalent(getOFRoot(), fs::path{ "../../.." })) {
-		string root { getOFRoot().string() };
-		string relRootWindows { convertStringToWindowsSeparator(root) + "\\" };
-
-		// sln has windows paths:
-//		alert ("replacing root with " + relRootWindows, 36);
-		findandreplaceInTexfile(solution, "..\\..\\..\\", relRootWindows);
-
-		// vcx has unixy paths:
-		//..\..\..\libs
-		findandreplaceInTexfile(project, "..\\..\\..\\", relRootWindows);
-	} else {
-//		cout << "equivalent to default ../../.." << endl;
-	}
+//	if (!fs::equivalent(getOFRoot(), fs::path{ "../../.." })) {
+//		string root { getOFRoot().string() };
+//		string relRootWindows { convertStringToWindowsSeparator(root) + "\\" };
+//
+//		// sln has windows paths:
+////		alert ("replacing root with " + relRootWindows, 36);
+//		findandreplaceInTexfile(solution, "..\\..\\..\\", relRootWindows);
+//
+//		// vcx has unixy paths:
+//		//..\..\..\libs
+//		findandreplaceInTexfile(project, "..\\..\\..\\", relRootWindows);
+//	} else {
+////		cout << "equivalent to default ../../.." << endl;
+//	}
 
 	return true;
 }
@@ -205,7 +265,7 @@ void visualStudioProject::addSrc(const fs::path & srcFile, const fs::path & fold
 			nodeAdded.append_child("Filter").append_child(pugi::node_pcdata).set_value(folder.c_str());*/
 
 		} else if (ext == ".storyboard" || ext == ".mm") {
-			// Do not add files for other platforms		
+			// Do not add files for other platforms
 		} else{
 			appendValue(doc, "ClCompile", "Include", srcFileString);
 

--- a/commandLine/src/projects/visualStudioProject.cpp
+++ b/commandLine/src/projects/visualStudioProject.cpp
@@ -8,17 +8,13 @@ bool visualStudioProject::createProjectFile(){
 //	alert("visualStudioProject::createProjectFile");
 
 	ensureDllDirectoriesExist();
-
 	solution = projectDir / (projectName + ".sln");
 
-//	findandreplaceInTexfile(solution, "emptyExample", projectName);
-//	findandreplaceInTexfile(user, "emptyExample", projectName);
-//	findandreplaceInTexfile(project, "emptyExample", projectName);
-	
 	std::pair <string, string> replacements;
 	if (!fs::equivalent(getOFRoot(), fs::path{ "../../.." })) {
 		string root { getOFRoot().string() };
 		string relRootWindows { convertStringToWindowsSeparator(root) + "\\" };
+		
 		replacements = { "..\\..\\..\\", relRootWindows };
 	} else {
 //		cout << "equivalent to default ../../.." << endl;
@@ -33,6 +29,7 @@ bool visualStudioProject::createProjectFile(){
 			replacements
 		}
 	});
+	
 	// project
 	copyTemplateFiles.push_back({
 		templatePath / "emptyExample.vcxproj",
@@ -43,6 +40,7 @@ bool visualStudioProject::createProjectFile(){
 		}
 
 	});
+	
 	// user
 	copyTemplateFiles.push_back({
 		templatePath / "emptyExample.vcxproj.user",
@@ -67,17 +65,6 @@ bool visualStudioProject::createProjectFile(){
 		c.run();
 	}
 
-	// fs::path project 	{ projectDir / (projectName + ".vcxproj") };
-	// fs::path user 		{ projectDir / (projectName + ".vcxproj.user") };
-	// fs::path filters	{ projectDir / (projectName + ".vcxproj.filters") };
-
-	// fs::copy(templatePath / "emptyExample.vcxproj", 		project, fs::copy_options::overwrite_existing);
-	// fs::copy(templatePath / "emptyExample.vcxproj.user", 	user, fs::copy_options::overwrite_existing);
-	// fs::copy(templatePath / "emptyExample.sln", 			solution, fs::copy_options::overwrite_existing);
-	// fs::copy(templatePath / "emptyExample.vcxproj.filters", filters, fs::copy_options::overwrite_existing);
-	// fs::copy(templatePath / "icon.rc", projectDir / "icon.rc", fs::copy_options::overwrite_existing);
-
-	// after copy, after all execution
 
 	 fs::path filters { projectDir / (projectName + ".vcxproj.filters") };
 
@@ -87,27 +74,6 @@ bool visualStudioProject::createProjectFile(){
 	} else {
 		ofLogVerbose() << "problem loading filter ";
 	}
-
-	// findandreplaceInTexfile(solution, "emptyExample", projectName);
-	// findandreplaceInTexfile(user, "emptyExample", projectName);
-	// findandreplaceInTexfile(project, "emptyExample", projectName);
-
-
-//	if (!fs::equivalent(getOFRoot(), fs::path{ "../../.." })) {
-//		string root { getOFRoot().string() };
-//		string relRootWindows { convertStringToWindowsSeparator(root) + "\\" };
-//
-//		// sln has windows paths:
-////		alert ("replacing root with " + relRootWindows, 36);
-//		findandreplaceInTexfile(solution, "..\\..\\..\\", relRootWindows);
-//
-//		// vcx has unixy paths:
-//		//..\..\..\libs
-//		findandreplaceInTexfile(project, "..\\..\\..\\", relRootWindows);
-//	} else {
-////		cout << "equivalent to default ../../.." << endl;
-//	}
-
 	return true;
 }
 

--- a/commandLine/src/projects/visualStudioProject.cpp
+++ b/commandLine/src/projects/visualStudioProject.cpp
@@ -44,7 +44,7 @@ bool visualStudioProject::createProjectFile(){
 	// user
 	copyTemplateFiles.push_back({
 		templatePath / "emptyExample.vcxproj.user",
-		projectDir / (projectName + ".vcxproj"),
+		projectDir / (projectName + ".vcxproj.user"),
 		{{ "emptyExample", projectName }}
 
 	});

--- a/commandLine/src/utils/Utils.h
+++ b/commandLine/src/utils/Utils.h
@@ -113,9 +113,3 @@ bool ofIsPathInPath(const fs::path & path, const fs::path & base);
  Idea: create an object to hold the origin and destination files, with renames where needed
  and string substitution, so we can avoid opening and writing multiple times the same file, less ssd wear.
  */
-struct fromToReplace {
-public:
-	fs::path from;
-	fs::path to;
-	std::vector <std::pair <string, string> > findReplaces;
-};


### PR DESCRIPTION
PG usually copy files from templates folder to project
renames them (or rename in the copy process)
replaces content inside of them (opening and saving)

this PR creates an object to hold the input file path (template), output file path (project) and replacement pairs
so it can do a straight copy if no replacements are asked
or open the files from source (template) 
replaces content
and write definitive content in the project folder.

it also address a problem in msys2 where std::filesystem is not considering overwrite_existing and throwing errors. it removes destination file before copying in msys2 only.