### PR TITLE
Apple Notorization 3147 change from altool to notarytool

### DIFF
--- a/scripts/osx/ci_build_pg.sh
+++ b/scripts/osx/ci_build_pg.sh
@@ -73,7 +73,7 @@ package_app(){
 		echo "Compressing PG app"
 		# need to upload zip of just app to apple for notarizing
 		zip --symlinks -r -q projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip projectGenerator-$PLATFORM/projectGenerator.app
-		xcrun altool --notarize-app --primary-bundle-id "com.electron.projectgenerator" --username "${GA_APPLE_USERNAME}" -p "${GA_APPLE_PASS}" --asc-provider "${GA_NOTARIZE_PROVIDER}" --file projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip
+		xcrun notarytool --notarize-app --primary-bundle-id "com.electron.projectgenerator" --username "${GA_APPLE_USERNAME}" -p "${GA_APPLE_PASS}" --asc-provider "${GA_NOTARIZE_PROVIDER}" --file projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip
 		mv projectGenerator-$PLATFORM/projectGenerator-$PLATFORM.zip ${PG_DIR}/../../../projectGenerator/projectGenerator-$PLATFORM.zip
 		cd ${PG_DIR}/../../../projectGenerator
 		echo "Final Directory contents: ${PG_DIR}/../../../projectGenerator"


### PR DESCRIPTION

![image](https://github.com/openframeworks/projectGenerator/assets/830748/fea35e30-f299-4d58-bdf6-5ab838f99af7)


https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool