### PR TITLE
XCode - src fix for recursive folders

### DIFF
--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PG_VERSION "40"
+#define PG_VERSION "41"
 
 #include "ofAddon.h"
 #include "ofFileUtils.h"

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -265,7 +265,7 @@ string xcodeProject::getFolderUUID(const fs::path & folder, bool isFolder, fs::p
 
 						if (!filePath.empty()) {
 							addCommand("Add :objects:"+thisUUID+":path string " + ofPathToString(filePath));
-//							alert(commands.back(), 33);
+							alert(commands.back(), 33);
 						} else {
 //							cout << ">>>>> filePath empty " << endl;
 						}
@@ -275,15 +275,15 @@ string xcodeProject::getFolderUUID(const fs::path & folder, bool isFolder, fs::p
 
 					addCommand("Add :objects:"+thisUUID+":isa string PBXGroup");
 					addCommand("Add :objects:"+thisUUID+":children array");
-					
-					if (folder.begin()->string() == "addons") {
-						addCommand("Add :objects:"+thisUUID+":sourceTree string <group>");
-						fs::path addonFolder { fs::path(fullPath).filename() };
-						addCommand("Add :objects:"+thisUUID+":path string " + ofPathToString(addonFolder));
-						// alert ("group " + folder.string() + " : " + base.string() + " : " + addonFolder.string(), 32);
-					} else {
-						addCommand("Add :objects:"+thisUUID+":sourceTree string SOURCE_ROOT");
-					}
+
+					addCommand("Add :objects:"+thisUUID+":sourceTree string <group>");
+					fs::path addonFolder { fs::path(fullPath).filename() };
+					addCommand("Add :objects:"+thisUUID+":path string " + ofPathToString(addonFolder));
+
+//					if (folder.begin()->string() == "addons") {
+//					} else {
+//						addCommand("Add :objects:"+thisUUID+":sourceTree string SOURCE_ROOT");
+//					}
 
 					// And this new object is cointained in parent hierarchy, or even projRootUUID
 					addCommand("Add :objects:"+lastFolderUUID+":children: string " + thisUUID);
@@ -686,7 +686,7 @@ void xcodeProject::addCommand(const string & command) {
 }
 
 string xcodeProject::addFile(const fs::path & path, const fs::path & folder, const fileProperties & fp) {
-//	alert("addFile " + ofPathToString(path) + " : " + ofPathToString(folder) , 31);
+	alert("addFile " + ofPathToString(path) + " : " + ofPathToString(folder) , 31);
 //	alert("reference " + ofToString(fp.reference));
 //	alert("addToBuildPhase " + ofToString(fp.addToBuildPhase));
 //	alert("codeSignOnCopy " + ofToString(fp.codeSignOnCopy));

--- a/commandLine/src/projects/xcodeProject.cpp
+++ b/commandLine/src/projects/xcodeProject.cpp
@@ -280,11 +280,6 @@ string xcodeProject::getFolderUUID(const fs::path & folder, bool isFolder, fs::p
 					fs::path addonFolder { fs::path(fullPath).filename() };
 					addCommand("Add :objects:"+thisUUID+":path string " + ofPathToString(addonFolder));
 
-//					if (folder.begin()->string() == "addons") {
-//					} else {
-//						addCommand("Add :objects:"+thisUUID+":sourceTree string SOURCE_ROOT");
-//					}
-
 					// And this new object is cointained in parent hierarchy, or even projRootUUID
 					addCommand("Add :objects:"+lastFolderUUID+":children: string " + thisUUID);
 
@@ -673,7 +668,6 @@ bool xcodeProject::saveProjectFile(){
 	}
 
 //	for (auto & c : commands) cout << c << endl;
-
 	return true;
 }
 
@@ -687,10 +681,6 @@ void xcodeProject::addCommand(const string & command) {
 
 string xcodeProject::addFile(const fs::path & path, const fs::path & folder, const fileProperties & fp) {
 	alert("addFile " + ofPathToString(path) + " : " + ofPathToString(folder) , 31);
-//	alert("reference " + ofToString(fp.reference));
-//	alert("addToBuildPhase " + ofToString(fp.addToBuildPhase));
-//	alert("codeSignOnCopy " + ofToString(fp.codeSignOnCopy));
-//	alert("copyFilesBuildPhase " + ofToString(fp.copyFilesBuildPhase));
 
 	string UUID = "";
 	std::map<fs::path, string> extensionToFileType {


### PR DESCRIPTION
Recursive folders in src files are now relative. 
Everything will be relative <group> unless explicitely marked as absolute (SOURCE_ROOT)