### PR TITLE
project override for template objects like plist fixes - compare and …

### DIFF
--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -5,7 +5,11 @@
 #include "ofAddon.h"
 #include "pugixml.hpp"
 #include <map>
+#include <iostream>
 #include <fstream>
+#include <filesystem>
+#include <string>
+#include <vector>
 
 namespace fs = of::filesystem;
 
@@ -121,55 +125,110 @@ protected:
 		fs::path to;
 		std::vector <std::pair <string, string> > findReplaces;
 		
-		bool run() {
-			// needed for mingw only. maybe a ifdef here.
-			if (fs::exists(from)) {
-#if defined(__MINGW32__) || defined(__MINGW64__)
-				if (fs::exists(to)) {
-					fs::remove(to);
-				}
-#endif
+        bool run() {
+               if (fs::exists(from)) {
+                   if (fs::exists(to)) {
+                       std::ifstream fileTo(to);
+                       std::string existingContents((std::istreambuf_iterator<char>(fileTo)), std::istreambuf_iterator<char>());
+                       fileTo.close();
 
-				if (findReplaces.size()) {
-					// Load file, replace contents, write to destination.
-					
-					std::ifstream fileFrom(from);
-					std::string contents((std::istreambuf_iterator<char>(fileFrom)), std::istreambuf_iterator<char>());
-					fileFrom.close();
+                       std::ifstream fileFrom(from);
+                       std::string templateContents((std::istreambuf_iterator<char>(fileFrom)), std::istreambuf_iterator<char>());
+                       fileFrom.close();
 
-					for (auto & f : findReplaces) {
-						replaceAll(contents, f.first, f.second);
-					}
-					
-					std::ofstream fileTo(to);
-					try{
-						fileTo << contents;
-					}catch(std::exception & e){
-						std::cout << "Error saving to " << to << " : " << e.what() << std::endl;
-						return false;
-					}catch(...){
-						std::cout << "Error saving to " << to << std::endl;
-						return false;
-					}
-					
-				} else {
-					// straight copy
-					try {
-						fs::copy(from, to, fs::copy_options::overwrite_existing);
-					}
-					catch(fs::filesystem_error & e) {
-						std::cout << "error copying template file " << from << " : " << to << std::endl;
-						std::cout << e.what() << std::endl;
-						return false;
-					}
-				}
-			} else {
-				return false;
-			}
+                       std::string mergedContents = mergePlistFiles(existingContents, templateContents);
 
-			return true;
-//			std::cout << "----" << std::endl;
-		}
+                       try {
+                           std::ofstream fileOut(to);
+                           fileOut << mergedContents;
+                       } catch (std::exception& e) {
+                           std::cout << "Error saving to " << to << " : " << e.what() << std::endl;
+                           return false;
+                       } catch (...) {
+                           std::cout << "Error saving to " << to << std::endl;
+                           return false;
+                       }
+                   } else {
+                       try {
+                           fs::copy(from, to, fs::copy_options::overwrite_existing);
+                       } catch (fs::filesystem_error& e) {
+                           std::cout << "error copying template file " << from << " to " << to << std::endl;
+                           std::cout << e.what() << std::endl;
+                           return false;
+                       }
+                   }
+               } else {
+                   return false;
+               }
+
+               return true;
+           }
+     
+
+       std::string mergePlistFiles(const std::string& existingContents, const std::string& templateContents) {
+           pugi::xml_document existingDoc;
+               existingDoc.load_string(existingContents.c_str());
+
+               pugi::xml_document templateDoc;
+               templateDoc.load_string(templateContents.c_str());
+
+               pugi::xml_node existingDict = existingDoc.child("plist").child("dict");
+               pugi::xml_node templateDict = templateDoc.child("plist").child("dict");
+
+               std::map<std::string, std::string> existingMap;
+               std::map<std::string, std::string> templateMap;
+
+               for (pugi::xml_node node = existingDict.first_child(); node; node = node.next_sibling("key")) {
+                   std::string key = node.child_value();
+                   std::string value;
+                   pugi::xml_node valueNode = node.next_sibling();
+                   if (std::string(valueNode.name()) == "string") {
+                       value = valueNode.child_value();
+                   } else {
+                       value = valueNode.name();
+                   }
+                   existingMap[key] = value;
+               }
+
+               for (pugi::xml_node node = templateDict.first_child(); node; node = node.next_sibling("key")) {
+                   std::string key = node.child_value();
+                   std::string value;
+                   pugi::xml_node valueNode = node.next_sibling();
+                   if (std::string(valueNode.name()) == "string") {
+                       value = valueNode.child_value();
+                   } else {
+                       value = valueNode.name();
+                   }
+                   templateMap[key] = value;
+               }
+
+               for (const auto& entry : templateMap) {
+                   if (existingMap.find(entry.first) == existingMap.end()) {
+                       existingMap[entry.first] = entry.second;
+                   }
+               }
+
+               std::string mergedContents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n";
+               for (const auto& entry : existingMap) {
+                   mergedContents += "    <key>" + entry.first + "</key>\n";
+                   if (entry.second == "true" || entry.second == "false") {
+                       mergedContents += "    <" + entry.second + "/>\n";
+                   } else {
+                       mergedContents += "    <string>" + entry.second + "</string>\n";
+                   }
+               }
+               mergedContents += "</dict>\n</plist>\n";
+
+               return mergedContents;
+       }
+
+        void replaceAll(std::string& str, const std::string& from, const std::string& to) {
+            size_t startPos = 0;
+            while ((startPos = str.find(from, startPos)) != std::string::npos) {
+                str.replace(startPos, from.length(), to);
+                startPos += to.length();
+            }
+        }
 	};
 
 	vector <copyTemplateFile> copyTemplateFiles;

--- a/commandLine/src/projects/baseProject.h
+++ b/commandLine/src/projects/baseProject.h
@@ -208,13 +208,13 @@ protected:
                    }
                }
 
-               std::string mergedContents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n";
+            std::string mergedContents = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n";
                for (const auto& entry : existingMap) {
-                   mergedContents += "    <key>" + entry.first + "</key>\n";
+                   mergedContents += "\t<key>" + entry.first + "</key>\n";
                    if (entry.second == "true" || entry.second == "false") {
-                       mergedContents += "    <" + entry.second + "/>\n";
+                       mergedContents += "\t<" + entry.second + "/>\n";
                    } else {
-                       mergedContents += "    <string>" + entry.second + "</string>\n";
+                       mergedContents += "\t<string>" + entry.second + "</string>\n";
                    }
                }
                mergedContents += "</dict>\n</plist>\n";


### PR DESCRIPTION
project override for template objects like plist fixes - compare now

manually add keys if missing from deployed file vs template (if we add new ones to template, it should add them) - not change the key value though, if does exist 

Fixes: https://github.com/openframeworks/projectGenerator/issues/542 with auto oF Path finder 