### PR TITLE
link xcframeworks like regular libs, avoids libs being copied to bin/…

### DIFF
--- a/commandLine/src/addons/ofAddon.cpp
+++ b/commandLine/src/addons/ofAddon.cpp
@@ -33,7 +33,9 @@ void ofAddon::getFrameworksRecursively(const fs::path & path, string platform) {
 						frameworks.emplace_back(f.string());
 					}
 					if (f.extension() == ".xcframework") {
+						if( platform != "macos" && platform != "osx" ){ //we don't want to add xcFrameworks for osx and just treat them like lib folders
 						xcframeworks.emplace_back(f.string());
+						}
 					}
 				}
 			}

--- a/commandLine/src/utils/Utils.cpp
+++ b/commandLine/src/utils/Utils.cpp
@@ -341,7 +341,7 @@ void getLibsRecursively(const fs::path & path, std::vector < fs::path > & libFil
 
 		if (fs::is_directory(f)) {
 			// on osx, framework is a directory, let's not parse it....
-			if ((f.extension() == ".framework") || (f.extension() == ".xcframework")) {
+			if ((f.extension() == ".framework") || (f.extension() == ".xcframework" && (platform != "osx" && platform != "macos")) ) { //we want to treat .xcframeworks as regular libs for macos
 				it.disable_recursion_pending();
 				continue;
 			} 


### PR DESCRIPTION
Closes #614
And closes https://github.com/openframeworks/openFrameworks/issues/8147