### PR TITLE
Include algorithm for std::find call

### DIFF
--- a/commandLine/src/utils/LibraryBinary.cpp
+++ b/commandLine/src/utils/LibraryBinary.cpp
@@ -1,5 +1,6 @@
 #include "LibraryBinary.h"
 #include "ofFileUtils.h"
+#include <algorithm>
 
 const std::vector<std::string> LibraryBinary::archs { "x86", "Win32", "x64", "armv7", "ARM64", "ARM64EC" };
 const std::vector<std::string> LibraryBinary::targets{ "Debug", "Release" };


### PR DESCRIPTION
Fix build on arch linux by adding missing include for std::find call