### PR TITLE
Fix compilation error on linux: std::find can't be found without incl…

### DIFF
--- a/commandLine/src/utils/LibraryBinary.h
+++ b/commandLine/src/utils/LibraryBinary.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
-
 
 #include "ofConstants.h"
 #include "defines.h"


### PR DESCRIPTION
It could probably be done importing utils.

Fixes https://github.com/openframeworks/openFrameworks/issues/8486 on openFrameworks compilation on linux systems